### PR TITLE
Prepare for alpha release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@ _testmain.go
 coverage.out
 .godeps/
 build/
+release/
 containerbuddy

--- a/makefile
+++ b/makefile
@@ -13,8 +13,9 @@ clean:
 
 # fetch dependencies
 .godeps:
-	mkdir -p .godeps/
-	GOPATH=${ROOT}/.godeps:${ROOT} go get github.com/hashicorp/consul/api
+	mkdir -p .godeps/src/github.com/hashicorp
+	git clone https://github.com/hashicorp/consul.git .godeps/src/github.com/hashicorp/consul
+	cd .godeps/src/github.com/hashicorp/consul && git checkout 158eabdd6f2408067c1d7656fa10e49434f96480
 
 # build our binary in a container
 build: .godeps consul

--- a/makefile
+++ b/makefile
@@ -3,25 +3,18 @@ SHELL := /bin/bash
 .SHELLFLAGS := -eu -o pipefail
 .DEFAULT_GOAL := build
 
-.PHONY: clean test run consul example ship
+.PHONY: clean test consul run example ship
 
+VERSION := 0.0.1-alpha
 ROOT := $(shell pwd)
 GO := docker run --rm --link containerbuddy_consul:consul -e CGO_ENABLED=0 -e GOPATH=/root/.godeps:/src -v ${ROOT}:/root -w /root/src/containerbuddy golang go
 
 clean:
-	rm -rf build # .godeps
+	rm -rf build release .godeps
 
-# fetch dependencies
-.godeps:
-	mkdir -p .godeps/src/github.com/hashicorp
-	git clone https://github.com/hashicorp/consul.git .godeps/src/github.com/hashicorp/consul
-	cd .godeps/src/github.com/hashicorp/consul && git checkout 158eabdd6f2408067c1d7656fa10e49434f96480
 
-# build our binary in a container
-build: .godeps consul
-	mkdir -p build
-	${GO} build -a -o /root/build/containerbuddy
-	chmod +x ${ROOT}/build/containerbuddy
+# ----------------------------------------------
+# develop and test
 
 # run unit tests and exec test
 test: .godeps consul
@@ -29,16 +22,50 @@ test: .godeps consul
 	${GO} test -v -coverprofile=/root/coverage.out
 	docker rm -f containerbuddy_consul || true
 
-# run main
-run: .godeps consul
-	@docker rm containerbuddy || true
-	docker run -d --name containerbuddy -e CGO_ENABLED=0 -e GOPATH=/root/.godeps:/src -v ${ROOT}:/root -w /root/src/containerbuddy golang go run main.go /root/examples/test.sh sleepStuff -debug
+# fetch dependencies
+.godeps:
+	mkdir -p .godeps/src/github.com/hashicorp
+	git clone https://github.com/hashicorp/consul.git .godeps/src/github.com/hashicorp/consul
+	cd .godeps/src/github.com/hashicorp/consul && git checkout 158eabdd6f2408067c1d7656fa10e49434f96480
 
 # run consul
 consul:
 	docker rm -f containerbuddy_consul || true
 	docker run -d -m 256m --name containerbuddy_consul \
 		progrium/consul:latest -server -bootstrap-expect 1 -ui-dir /ui
+
+
+# ----------------------------------------------
+# build and release
+
+# build our binary in a container
+build: .godeps
+	mkdir -p build
+	docker run --rm -e CGO_ENABLED=0 \
+			-e GOPATH=/root/.godeps:/src \
+			-v ${ROOT}:/root \
+			-w /root/src/containerbuddy \
+			golang \
+			go build -a -o /root/build/containerbuddy
+	chmod +x ${ROOT}/build/containerbuddy
+
+# create the files we need for an official release on Github
+release: build
+	mkdir -p release
+	git tag $(VERSION)
+	git push origin --tags
+	tar -czf release/containerbuddy-$(VERSION).tar.gz build/containerbuddy
+	@echo
+	@echo Upload this file to Github release:
+	@sha1sum release/containerbuddy-$(VERSION).tar.gz
+
+# ----------------------------------------------
+# example application
+
+# run main
+run: .godeps consul
+	@docker rm containerbuddy || true
+	docker run -d --name containerbuddy -e CGO_ENABLED=0 -e GOPATH=/root/.godeps:/src -v ${ROOT}:/root -w /root/src/containerbuddy golang go run main.go /root/examples/test.sh sleepStuff -debug
 
 # build Nginx and App examples
 example: build


### PR DESCRIPTION
@misterbisson this PR:
- pins the version of the consul API library we're using to one we've tested to work previously and that predates a build-breaking refactoring on consul's `master`
- adds a `release` target to the makefile so we can tag releases: this creates a git tag for the value of `$VERSION` and also creates a tarball suitable to upload to Github. (Maybe in some future version of this build we can have the release created automatically on Github but for now doing OAuth via makefile sounded unpleasant).