### PR TITLE
new docker version change ip on container restart

### DIFF
--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -91,12 +91,12 @@ func loadConfig() *Config {
 		backend.onChangeArgs = strings.Split(backend.OnChangeExec, " ")
 	}
 
-	hostname, _ := os.Hostname()
 	for _, service := range config.Services {
-		service.Id = fmt.Sprintf("%s-%s", service.Name, hostname)
+		hostIP := getIp(service.IsPublic)
+		service.Id = fmt.Sprintf("%s-%s", service.Name, hostIP)
 		service.discoveryService = discovery
 		service.healthArgs = strings.Split(service.HealthCheckExec, " ")
-		service.ipAddress = getIp(service.IsPublic)
+		service.ipAddress = hostIP
 	}
 
 	return config


### PR DESCRIPTION
Hi, 
When service restarts, no ip info it being updated on consul, so change hostname by host ip on service id for service registration.

Best regards