### PR TITLE
Support user-defined onStart behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The format of the JSON file configuration is as follows:
 ```json
 {
   "consul": "consul:8500",
+  "onStart": "/opt/containerbuddy/onStart-script.sh",
   "services": [
     {
       "name": "app",
@@ -80,6 +81,10 @@ Backend fields:
 - `name` is the name of a backend service that this container depends on, as it will appear in Consul.
 - `poll` is the time in seconds between polling for changes.
 - `onChange` is the executable (and its arguments) that is called when there is a change in the list of IPs and ports for this backend.
+
+Other fields:
+- `consul` is the hostname and port of the Consul discovery service.
+- `onStart` is the executable (and its arguments) that will be called immediately prior to starting the shimmed application. This field is optional.
 
 *Note that if you're using `curl` to check HTTP endpoints for health checks, that it doesn't return a non-zero exit code on 404s or similar failure modes by default. Use the `--fail` flag for curl if you need to catch those cases.*
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# containerbuddy
+# Containerbuddy
 
 *A service for assisting discovery and configuration of applications running in containers.*
 
@@ -12,21 +12,21 @@ We can wrap each application in a shell script that registers itself with the di
 Additionally, discovery services like Consul provide a means of performing health checks from outside our container, but that means packaging the tooling we need into the Consul container. If we need to change the health check, then we end up re-deploying both our application and Consul, which unnecessarily couples the two.
 
 
-### containerbuddy to the rescue!
+### Containerbuddy to the rescue!
 
-containerbuddy is a shim written in Go to help make it easier to containerize existing applications. It can act as PID1 in the container and fork/exec the application. If the application exits then so does containerbuddy.
+Containerbuddy is a shim written in Go to help make it easier to containerize existing applications. It can act as PID1 in the container and fork/exec the application. If the application exits then so does Containerbuddy.
 
-Alternately, if your application double-forks (which is not recommended for containerized applications but hey we are taking about pre-container apps here!), you can run containerbuddy as a side-by-side buddy process within the container. In that case the container will not die if the application dies, which can create complicated failure modes but which can be mitigated by having a good TTL health check to detect the problem and alert you.
+Alternately, if your application double-forks (which is not recommended for containerized applications but hey we are taking about pre-container apps here!), you can run Containerbuddy as a side-by-side buddy process within the container. In that case the container will not die if the application dies, which can create complicated failure modes but which can be mitigated by having a good TTL health check to detect the problem and alert you.
 
-containerbuddy registers the application with Consul on start and periodically sends TTL health checks to Consul; should the application fail then Consul will not receive the health check and once the TTL expires will no longer consider the application node healthy. Meanwhile, containerbuddy runs background workers that poll Consul, checking for changes in dependent/upstream service, and calling an external executable on change.
+Containerbuddy registers the application with Consul on start and periodically sends TTL health checks to Consul; should the application fail then Consul will not receive the health check and once the TTL expires will no longer consider the application node healthy. Meanwhile, Containerbuddy runs background workers that poll Consul, checking for changes in dependent/upstream service, and calling an external executable on change.
 
 Using local scripts to test health or act on backend changes means that we can run health checks that are specific to the service in the container, which keeps orchestration and the application bundled together.
 
-containerbuddy is explicitly *not* a supervisor process. Although it can act as PID1 inside a container, if the shimmed process dies, so does containerbuddy (and therefore the container itself). containerbuddy will return the exit code of its shimmed process back to the Docker Engine or Triton, so that it appears as expected when you run `docker ps -a` and look for your exit codes. containerbuddy also attaches stdout/stderr from your application to stdout/stderr of the container, so that `docker logs` works as expected.
+Containerbuddy is explicitly *not* a supervisor process. Although it can act as PID1 inside a container, if the shimmed process dies, so does Containerbuddy (and therefore the container itself). Containerbuddy will return the exit code of its shimmed process back to the Docker Engine or Triton, so that it appears as expected when you run `docker ps -a` and look for your exit codes. Containerbuddy also attaches stdout/stderr from your application to stdout/stderr of the container, so that `docker logs` works as expected.
 
-### Configuring containerbuddy
+### Configuring Containerbuddy
 
-containerbuddy takes a single file argument (or a JSON string) as its configuration. All trailing arguments will be treated as the executable to shim and that executable's arguments.
+Containerbuddy takes a single file argument (or a JSON string) as its configuration. All trailing arguments will be treated as the executable to shim and that executable's arguments.
 
 ```bash
 # configure via passing a file argument
@@ -84,7 +84,7 @@ Backend fields:
 
 Other fields:
 - `consul` is the hostname and port of the Consul discovery service.
-- `onStart` is the executable (and its arguments) that will be called immediately prior to starting the shimmed application. This field is optional.
+- `onStart` is the executable (and its arguments) that will be called immediately prior to starting the shimmed application. This field is optional. If the `onStart` handler returns a non-zero exit code, Containerbuddy will exit.
 
 *Note that if you're using `curl` to check HTTP endpoints for health checks, that it doesn't return a non-zero exit code on 404s or similar failure modes by default. Use the `--fail` flag for curl if you need to catch those cases.*
 
@@ -94,7 +94,7 @@ Please report any issues you encounter with Containerbuddy or its documentation 
 
 ### Running the example
 
-In the `examples` directory is a simple application demonstrating how containerbuddy works. In this application, an Nginx node acts as a reverse proxy for any number of upstream application nodes. The application nodes register themselves with Consul as they come online, and the Nginx application is configured with an `onChange` handler that uses `consul-template` to write out a new virtualhost configuration file and then fires an `nginx -s reload` signal to Nginx, which causes it to gracefully reload its configuration.
+In the `examples` directory is a simple application demonstrating how Containerbuddy works. In this application, an Nginx node acts as a reverse proxy for any number of upstream application nodes. The application nodes register themselves with Consul as they come online, and the Nginx application is configured with an `onChange` handler that uses `consul-template` to write out a new virtualhost configuration file and then fires an `nginx -s reload` signal to Nginx, which causes it to gracefully reload its configuration.
 
 To try this example on your own:
 

--- a/examples/app/opt/containerbuddy/app.json
+++ b/examples/app/opt/containerbuddy/app.json
@@ -1,5 +1,6 @@
 {
   "consul": "consul:8500",
+  "onStart": "/opt/containerbuddy/reload-app.sh",
   "services": [
     {
       "name": "app",

--- a/makefile
+++ b/makefile
@@ -22,6 +22,11 @@ test: .godeps consul
 	${GO} test -v -coverprofile=/root/coverage.out
 	docker rm -f containerbuddy_consul || true
 
+cover: test
+	@sed -i 's/_\/root\/src\///' coverage.out
+	go tool cover -html=coverage.out
+
+
 # fetch dependencies
 .godeps:
 	mkdir -p .godeps/src/github.com/hashicorp

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -12,9 +12,11 @@ import (
 )
 
 type Config struct {
-	Consul	     string          `json:"consul,omitempty"`
-	Services     []*ServiceConfig `json:"services"`
-	Backends     []*BackendConfig `json:"backends"`
+	Consul      string `json:"consul,omitempty"`
+	OnStart     string `json:"onStart"`
+	onStartArgs []string
+	Services    []*ServiceConfig `json:"services"`
+	Backends    []*BackendConfig `json:"backends"`
 }
 
 type ServiceConfig struct {
@@ -85,6 +87,8 @@ func loadConfig() *Config {
 	} else if discoveryCount > 1 {
 		log.Fatal("More than one discovery backend defined")
 	}
+
+	config.onStartArgs = strings.Split(config.OnStart, " ")
 
 	for _, backend := range config.Backends {
 		backend.discoveryService = discovery

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 )
 
-var testJson = `{
+func TestValidConfigParse(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	var testJson = `{
     "consul": "consul:8500",
     "onStart": "/bin/to/onStart.sh",
     "services": [
@@ -41,24 +43,44 @@ var testJson = `{
 }
 `
 
-func TestConfigParse(t *testing.T) {
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
-	flag.Usage = nil
-	oldArgs := os.Args
-	defer func() { os.Args = oldArgs }()
-	os.Args = []string{"this", "-config", testJson, "/root/examples/test.sh", "doStuff", "--debug"}
+	os.Args = []string{"this", "-config", testJson, "/test.sh", "valid1", "--debug"}
 	config, _ := loadConfig()
 
 	if len(config.Backends) != 2 || len(config.Services) != 2 {
 		t.Errorf("Expected 2 backends and 2 services but got: %v", config)
 	}
 	args := flag.Args()
-	if len(args) != 3 || args[0] != "/root/examples/test.sh" {
+	if len(args) != 3 || args[0] != "/test.sh" {
 		t.Errorf("Expected 3 args but got unexpected results: %v", args)
 	}
 	if config.OnStart != "/bin/to/onStart.sh" {
 		t.Errorf("onStart not configured")
 	}
+}
+
+func TestInvalidConfigNoConfigFlag(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	os.Args = []string{"this", "/test.sh", "invalid1", "--debug"}
+	if _, err := loadConfig(); err != nil && err.Error() != "-config flag is required." {
+		t.Errorf("Expected error but got %s", err)
+	}
+}
+
+func TestInvalidConfigParseNoDiscovery(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	testParseExpectError(t, "{}", "No discovery backend defined")
+}
+
+func TestInvalidConfigParseFile(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	testParseExpectError(t, "file:///xxxx",
+		"Could not read config file: open /xxxx: no such file or directory")
+}
+
+func TestInvalidConfigParseNotJson(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	testParseExpectError(t, "<>",
+		"Could not parse configuration: invalid character '<' looking for beginning of value")
 }
 
 func TestGetIp(t *testing.T) {
@@ -94,5 +116,25 @@ func TestIpCheckPublic(t *testing.T) {
 		if !isPublicIp(ip) {
 			t.Errorf("Expected %s to be identified as public IP but got private.", ip)
 		}
+	}
+}
+
+// ----------------------------------------------------
+// test helpers
+
+func argTestSetup() []string {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	flag.Usage = nil
+	return os.Args
+}
+
+func argTestCleanup(oldArgs []string) {
+	os.Args = oldArgs
+}
+
+func testParseExpectError(t *testing.T, testJson string, expected string) {
+	os.Args = []string{"this", "-config", testJson, "/test.sh", "test", "--debug"}
+	if _, err := loadConfig(); err != nil && err.Error() != expected {
+		t.Errorf("Expected %s but got %s", expected, err)
 	}
 }

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -47,7 +47,7 @@ func TestConfigParse(t *testing.T) {
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 	os.Args = []string{"this", "-config", testJson, "/root/examples/test.sh", "doStuff", "--debug"}
-	config := loadConfig()
+	config, _ := loadConfig()
 
 	if len(config.Backends) != 2 || len(config.Services) != 2 {
 		t.Errorf("Expected 2 backends and 2 services but got: %v", config)

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -9,6 +9,7 @@ import (
 
 var testJson = `{
     "consul": "consul:8500",
+    "onStart": "/bin/to/onStart.sh",
     "services": [
         {
             "name": "serviceA",
@@ -54,6 +55,9 @@ func TestConfigParse(t *testing.T) {
 	args := flag.Args()
 	if len(args) != 3 || args[0] != "/root/examples/test.sh" {
 		t.Errorf("Expected 3 args but got unexpected results: %v", args)
+	}
+	if config.OnStart != "/bin/to/onStart.sh" {
+		t.Errorf("onStart not configured")
 	}
 }
 

--- a/src/containerbuddy/main.go
+++ b/src/containerbuddy/main.go
@@ -11,6 +11,16 @@ import (
 
 func main() {
 	config := loadConfig()
+
+	// Run the onStart handler, if any, and exit if it returns an error
+	if config.OnStart != "" {
+		code, err := run(config.onStartArgs)
+		if err != nil {
+			log.Println(err)
+			os.Exit(code)
+		}
+	}
+
 	var quit []chan bool
 	for _, backend := range config.Backends {
 		quit = append(quit, poll(backend, checkForChanges, backend.onChangeArgs))

--- a/src/containerbuddy/main.go
+++ b/src/containerbuddy/main.go
@@ -10,7 +10,10 @@ import (
 )
 
 func main() {
-	config := loadConfig()
+	config, configErr := loadConfig()
+	if configErr != nil {
+		log.Fatal(configErr)
+	}
 
 	// Run the onStart handler, if any, and exit if it returns an error
 	if config.OnStart != "" {


### PR DESCRIPTION
This PR provides https://github.com/joyent/containerbuddy/issues/13

- Runs a user-defined `onStart` executable prior to running the main application or any of the health check or discovery goroutines.
- Made config parsing more testable and expanded test coverage

@misterbisson to review please