### PR TITLE
Add interface option to ServiceConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The format of the JSON file configuration is as follows:
       "name": "app",
       "port": 80,
       "health": "/usr/bin/curl --fail -s http://localhost/app",
-      "interface": "eth0",
+      "interfaces": ["eth0"],
       "poll": 10,
       "ttl": 30
     }
@@ -74,7 +74,7 @@ Service fields:
 - `name` is the name of the service as it will appear in Consul. Each instance of the service will have a unique ID made up from `name`+hostname of the container.
 - `port` is the port the service will advertise to Consul.
 - `health` is the executable (and its arguments) used to check the health of the service.
-- `interface` is an optional setting indicating the interface from which the IP will be discovered. Default value is `eth0` if not given.
+- `interfaces` is an optional array of interfaces in priority order. If given, the IP of the service will be obtained from the first interface found that matches a name in this list. (Default value is `["eth0"]`)
 - `poll` is the time in seconds between polling for health checks.
 - `ttl` is the time-to-live of a successful health check. This should be longer than the polling rate so that the polling process and the TTL aren't racing; otherwise Consul will mark the service as unhealthy.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The format of the JSON file configuration is as follows:
       "name": "app",
       "port": 80,
       "health": "/usr/bin/curl --fail -s http://localhost/app",
-      "publicIp": false,
+      "interface": "eth0",
       "poll": 10,
       "ttl": 30
     }
@@ -70,19 +70,22 @@ The format of the JSON file configuration is as follows:
 ```
 
 Service fields:
+
 - `name` is the name of the service as it will appear in Consul. Each instance of the service will have a unique ID made up from `name`+hostname of the container.
 - `port` is the port the service will advertise to Consul.
 - `health` is the executable (and its arguments) used to check the health of the service.
-- `publicIp` is an optional boolean flag indicating whether the service should advertise its public IP, rather than its private IP (defaults to private/`false`).
+- `interface` is an optional setting indicating the interface from which the IP will be discovered. Default value is `eth0` if not given.
 - `poll` is the time in seconds between polling for health checks.
 - `ttl` is the time-to-live of a successful health check. This should be longer than the polling rate so that the polling process and the TTL aren't racing; otherwise Consul will mark the service as unhealthy.
 
 Backend fields:
+
 - `name` is the name of a backend service that this container depends on, as it will appear in Consul.
 - `poll` is the time in seconds between polling for changes.
 - `onChange` is the executable (and its arguments) that is called when there is a change in the list of IPs and ports for this backend.
 
 Other fields:
+
 - `consul` is the hostname and port of the Consul discovery service.
 - `onStart` is the executable (and its arguments) that will be called immediately prior to starting the shimmed application. This field is optional. If the `onStart` handler returns a non-zero exit code, Containerbuddy will exit.
 

--- a/examples/nginx/opt/containerbuddy/nginx.json
+++ b/examples/nginx/opt/containerbuddy/nginx.json
@@ -4,7 +4,7 @@
     {
       "name": "nginx",
       "port": 80,
-      "publicIp": true,
+      "interface": "eth0",
       "health": "/usr/bin/curl --fail -s http://localhost/health.txt",
       "poll": 10,
       "ttl": 25

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -26,7 +26,7 @@ type ServiceConfig struct {
 	HealthCheckExec  string   `json:"health"`
 	Port             int      `json:"port"`
 	TTL              int      `json:"ttl"`
-	Interfaces       []string `json:"interface"`
+	Interfaces       []string `json:"interfaces"`
 	discoveryService DiscoveryService
 	healthArgs       []string
 	ipAddress        string

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -139,7 +139,7 @@ func parseConfig(configFlag string) (*Config, error) {
 }
 
 // determine the IP address of the container
-func getIp(interfaceName string) (string,error) {
+func getIp(interfaceName string) (string, error) {
 	if interfaceName == "" {
 		// Use a sane default
 		interfaceName = "eth0"
@@ -154,11 +154,11 @@ func getIp(interfaceName string) (string,error) {
 		// nor Triton sets up IP aliasing.
 		ipAddr, _, _ := net.ParseCIDR(ipAddrs[0].String())
 		if interfaceName == intf.Name {
-			return ipAddr.String(),nil
+			return ipAddr.String(), nil
 		}
 		foundInterfaces = append(foundInterfaces, intf.Name)
 	}
-	return "",errors.New(fmt.Sprintf("Unable to find interface %s in %s", interfaceName, foundInterfaces))
+	return "", errors.New(fmt.Sprintf("Unable to find interface %s in %s", interfaceName, foundInterfaces))
 }
 
 // parse an IPv4 address and return true if it's a public IP

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -83,16 +83,22 @@ func TestInvalidConfigParseNotJson(t *testing.T) {
 }
 
 func TestGetIp(t *testing.T) {
-	if ip, _ := getIp(""); ip == "" {
+	if ip, _ := getIp([]string{}); ip == "" {
 		t.Errorf("Expected default interface to yield an IP, but got nothing.")
 	}
-	if ip, _ := getIp("eth0"); ip == "" {
+	if ip, _ := getIp(nil); ip == "" {
+		t.Errorf("Expected default interface to yield an IP, but got nothing.")
+	}
+	if ip, _ := getIp([]string{"eth0"}); ip == "" {
 		t.Errorf("Expected to find IP for eth0, but found nothing.")
 	}
-	if ip, _ := getIp("lo"); ip != "127.0.0.1" {
+	if ip, _ := getIp([]string{"eth0", "lo"}); ip == "127.0.0.1" {
+		t.Errorf("Expected to find eth0 ip, but found loopback instead")
+	}
+	if ip, _ := getIp([]string{"lo", "eth0"}); ip != "127.0.0.1" {
 		t.Errorf("Expected to find loopback ip, but found: %s", ip)
 	}
-	if ip, err := getIp("interface-does-not-exist"); err == nil {
+	if ip, err := getIp([]string{"interface-does-not-exist"}); err == nil {
 		t.Errorf("Expected interface not found, but instead got an IP: %s", ip)
 	}
 }

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"net"
 	"os"
 	"testing"
 )
@@ -84,41 +83,17 @@ func TestInvalidConfigParseNotJson(t *testing.T) {
 }
 
 func TestGetIp(t *testing.T) {
-	if ip := getIp(false,""); ip == "" {
-		t.Errorf("Expected private IP but got nothing")
+	if ip,_ := getIp(""); ip == "" {
+		t.Errorf("Expected default interface to yield an IP, but got nothing.")
 	}
-	if ip := getIp(true,""); ip != "" {
-		t.Errorf("Expected no public IP but got: %s", ip)
+	if ip,_ := getIp("eth0"); ip == "" {
+		t.Errorf("Expected to find IP for eth0, but found nothing.")
 	}
-	if ip := getIp(true,"eth0"); ip == "" {
-		t.Errorf("Expected interface IP but got nothing")
+	if ip,_ := getIp("lo"); ip != "127.0.0.1" {
+		t.Errorf("Expected to find loopback ip, but found: %s",ip)
 	}
-}
-
-func TestIpCheckPrivate(t *testing.T) {
-	var privateIps = []string{
-		"192.168.1.117",
-		"172.17.1.1",
-		"10.1.1.13",
-	}
-	for _, ipAddr := range privateIps {
-		ip := net.ParseIP(ipAddr)
-		if isPublicIp(ip) {
-			t.Errorf("Expected %s to be identified as private IP but got public.", ip)
-		}
-	}
-}
-
-func TestIpCheckPublic(t *testing.T) {
-	var publicIps = []string{
-		"8.8.8.8",
-		"72.2.117.118",
-	}
-	for _, ipAddr := range publicIps {
-		ip := net.ParseIP(ipAddr)
-		if !isPublicIp(ip) {
-			t.Errorf("Expected %s to be identified as public IP but got private.", ip)
-		}
+	if ip,err := getIp("interface-does-not-exist"); err == nil {
+		t.Errorf("Expected interface not found, but instead got an IP: %s",ip)
 	}
 }
 

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -84,11 +84,14 @@ func TestInvalidConfigParseNotJson(t *testing.T) {
 }
 
 func TestGetIp(t *testing.T) {
-	if ip := getIp(false); ip == "" {
+	if ip := getIp(false,""); ip == "" {
 		t.Errorf("Expected private IP but got nothing")
 	}
-	if ip := getIp(true); ip != "" {
+	if ip := getIp(true,""); ip != "" {
 		t.Errorf("Expected no public IP but got: %s", ip)
+	}
+	if ip := getIp(true,"eth0"); ip == "" {
+		t.Errorf("Expected interface IP but got nothing")
 	}
 }
 

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -83,17 +83,17 @@ func TestInvalidConfigParseNotJson(t *testing.T) {
 }
 
 func TestGetIp(t *testing.T) {
-	if ip,_ := getIp(""); ip == "" {
+	if ip, _ := getIp(""); ip == "" {
 		t.Errorf("Expected default interface to yield an IP, but got nothing.")
 	}
-	if ip,_ := getIp("eth0"); ip == "" {
+	if ip, _ := getIp("eth0"); ip == "" {
 		t.Errorf("Expected to find IP for eth0, but found nothing.")
 	}
-	if ip,_ := getIp("lo"); ip != "127.0.0.1" {
-		t.Errorf("Expected to find loopback ip, but found: %s",ip)
+	if ip, _ := getIp("lo"); ip != "127.0.0.1" {
+		t.Errorf("Expected to find loopback ip, but found: %s", ip)
 	}
-	if ip,err := getIp("interface-does-not-exist"); err == nil {
-		t.Errorf("Expected interface not found, but instead got an IP: %s",ip)
+	if ip, err := getIp("interface-does-not-exist"); err == nil {
+		t.Errorf("Expected interface not found, but instead got an IP: %s", ip)
 	}
 }
 


### PR DESCRIPTION
- Adds the ability to override the interface from which containerbuddy
  gets its IP address. If the interface is found, it takes precedence
  over the "publicIp" option.

- Fixes #20