### PR TITLE
Deregister services on SIGTERM

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ docker exec myapp_1 kill -USR1 1
 
 ```
 
-Docker will automatically deliver a `SIGTERM` with `docker stop`; Not when using `docker kill`.  When Containerbuddy receives a `SIGTERM`, it will propagate this signal to the application and wait for `stopTimeout` seconds before forcing the application to stop. Make sure this timeout is less than the docker stop timout period or services may not deregister from the discovery service backend. If `-1` is given for `stopTimeout`, Containerbuddy will kill the application immediately with `SIGKILL`, but it will still deregister the services.
+Docker will automatically deliver a `SIGTERM` with `docker stop`, not when using `docker kill`.  When Containerbuddy receives a `SIGTERM`, it will propagate this signal to the application and wait for `stopTimeout` seconds before forcing the application to stop. Make sure this timeout is less than the docker stop timeout period or services may not deregister from the discovery service backend. If `-1` is given for `stopTimeout`, Containerbuddy will kill the application immediately with `SIGKILL`, but it will still deregister the services.
 
 *Caveat*: If Containerbuddy is wrapped as a shell command, such as: `/bin/sh -c '/opt/containerbuddy .... '` then `SIGTERM` will not reach Containerbuddy from `docker stop`.  This is important for systems like Mesos which may use a shell command as the entrypoint under default configuration.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Other fields:
 
 - `consul` is the hostname and port of the Consul discovery service.
 - `onStart` is the executable (and its arguments) that will be called immediately prior to starting the shimmed application. This field is optional. If the `onStart` handler returns a non-zero exit code, Containerbuddy will exit.
+- `stopTimeout` Optional amount of time in seconds to wait before killing the application. (defaults to `5`) When Containerbuddy receives a SIGTERM, it will propagate this signal to the application and wait this many seconds before forcing the application to stop. Make sure this timeout is less than the docker stop timout period or services may not deregister from the discovery service backend.
 
 *Note that if you're using `curl` to check HTTP endpoints for health checks, that it doesn't return a non-zero exit code on 404s or similar failure modes by default. Use the `--fail` flag for curl if you need to catch those cases.*
 
@@ -95,6 +96,7 @@ Other fields:
 
 Containerbuddy accepts POSIX signals to change its runtime behavior. Currently, Containerbuddy accepts the following signals.
 - `SIGUSR1` will cause Containerbuddy to mark its advertised service for maintenance. Containerbuddy will stop sending heartbeat messages to the discovery service. The discovery service backend's `MarkForMaintenance` method will also be called (in the default Consul implementation, this deregisters the node from Consul).
+- `SIGTERM` will cause Containerbuddy to send SIGTERM to the application, and eventually exit in a timely manner (as specified by StopTimeout).
 
 Delivering a signal to Containerbuddy is most easily done by using `docker exec` and relying on the fact that it is being used as PID1.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The format of the JSON file configuration is as follows:
 {
   "consul": "consul:8500",
   "onStart": "/opt/containerbuddy/onStart-script.sh",
+  "stopTimeout": 5,
   "services": [
     {
       "name": "app",

--- a/examples/test/test.sh
+++ b/examples/test/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+trap 'exit 2' SIGTERM
+
 usage() {
     cat <<EOF
 usage: $0 [COMMAND]
@@ -20,7 +22,14 @@ failStuff() {
 
 sleepStuff() {
     echo "Sleeping 10 seconds..."
-    sleep 5
+    sleep 10
+}
+
+interruptSleep() {
+  for i in {1..10}; do
+    echo -n "."
+    sleep 1
+  done
 }
 
 cmd="${1:-usage}"

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -72,7 +72,7 @@ func (s *ServiceConfig) Deregister() {
 
 const (
 	// Amount of time to wait before killing the application
-	DEFAULT_STOP_TIMEOUT int = 5
+	defaultStopTimeout int = 5
 )
 
 func loadConfig() (*Config, error) {
@@ -108,7 +108,7 @@ func loadConfig() (*Config, error) {
 	}
 
 	if config.StopTimeout == 0 {
-		config.StopTimeout = DEFAULT_STOP_TIMEOUT
+		config.StopTimeout = defaultStopTimeout
 	}
 
 	config.onStartArgs = strings.Split(config.OnStart, " ")

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -13,13 +13,14 @@ import (
 )
 
 type Config struct {
-	Consul      string `json:"consul,omitempty"`
-	OnStart     string `json:"onStart"`
-	StopTimeout int    `json:"stopTimeout"`
-	onStartArgs []string
-	Command     *exec.Cmd
-	Services    []*ServiceConfig `json:"services"`
-	Backends    []*BackendConfig `json:"backends"`
+	Consul       string `json:"consul,omitempty"`
+	OnStart      string `json:"onStart"`
+	StopTimeout  int    `json:"stopTimeout"`
+	onStartArgs  []string
+	Command      *exec.Cmd
+	QuitChannels []chan bool
+	Services     []*ServiceConfig `json:"services"`
+	Backends     []*BackendConfig `json:"backends"`
 }
 
 type ServiceConfig struct {

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -70,6 +70,11 @@ func (s *ServiceConfig) Deregister() {
 	s.discoveryService.Deregister(s)
 }
 
+const (
+	// Amount of time to wait before killing the application
+	DEFAULT_STOP_TIMEOUT int = 5
+)
+
 func loadConfig() (*Config, error) {
 
 	var configFlag string
@@ -103,7 +108,7 @@ func loadConfig() (*Config, error) {
 	}
 
 	if config.StopTimeout == 0 {
-		config.StopTimeout = 10
+		config.StopTimeout = DEFAULT_STOP_TIMEOUT
 	}
 
 	config.onStartArgs = strings.Split(config.OnStart, " ")

--- a/src/containerbuddy/consul.go
+++ b/src/containerbuddy/consul.go
@@ -18,6 +18,11 @@ func NewConsulConfig(uri string) Consul {
 	return *config
 }
 
+// Deregister removes the node from Consul.
+func (c Consul) Deregister(service *ServiceConfig) {
+	c.MarkForMaintenance(service)
+}
+
 // MarkForMaintenance removes the node from Consul.
 func (c Consul) MarkForMaintenance(service *ServiceConfig) {
 	if err := c.Agent().ServiceDeregister(service.Id); err != nil {

--- a/src/containerbuddy/discovery.go
+++ b/src/containerbuddy/discovery.go
@@ -4,4 +4,5 @@ type DiscoveryService interface {
 	SendHeartbeat(*ServiceConfig)
 	CheckForUpstreamChanges(*BackendConfig) bool
 	MarkForMaintenance(*ServiceConfig)
+	Deregister(*ServiceConfig)
 }

--- a/src/containerbuddy/main.go
+++ b/src/containerbuddy/main.go
@@ -35,6 +35,7 @@ func main() {
 	for _, service := range config.Services {
 		quit = append(quit, poll(service, checkHealth, service.healthArgs))
 	}
+	config.QuitChannels = quit
 
 	// gracefully clean up so that our docker logs aren't cluttered after an exit 0
 	// TODO: do we really need this?
@@ -53,21 +54,12 @@ func main() {
 		if err != nil {
 			log.Println(err)
 		}
-		deregisterServices(config)
 		os.Exit(code)
 	}
 
 	// block forever, as we're polling in the two polling functions and
 	// did not os.Exit by waiting on an external application.
 	select {}
-}
-
-func deregisterServices(config *Config) {
-	log.Println("Deregister All Services")
-	for _, service := range config.Services {
-		log.Printf("Deregister service: %s\n", service.Name)
-		service.Deregister()
-	}
 }
 
 type pollingFunc func(Pollable, []string)

--- a/src/containerbuddy/signals.go
+++ b/src/containerbuddy/signals.go
@@ -30,7 +30,8 @@ func toggleMaintenanceMode() {
 func terminate(config *Config) {
 	cmd := config.Command
 	if cmd == nil || cmd.Process == nil {
-		panic("cmd or cmd.Process is nil")
+		// Not managing the process, so don't do anything
+		return
 	}
 	if config.StopTimeout > 0 {
 		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {

--- a/src/containerbuddy/signals.go
+++ b/src/containerbuddy/signals.go
@@ -48,6 +48,20 @@ func terminate(config *Config) {
 	cmd.Process.Kill()
 }
 
+func stopPolling(config *Config) {
+	for _, quit := range config.QuitChannels {
+		quit <- true
+	}
+}
+
+func deregisterServices(config *Config) {
+	log.Println("Deregister All Services")
+	for _, service := range config.Services {
+		log.Printf("Deregister service: %s\n", service.Name)
+		service.Deregister()
+	}
+}
+
 // Listen for and capture signals from the OS
 func handleSignals(config *Config) {
 	sig := make(chan os.Signal, 1)
@@ -68,6 +82,8 @@ func handleSignals(config *Config) {
 				}
 			case syscall.SIGTERM:
 				log.Println("Caught SIGTERM")
+				stopPolling(config)
+				deregisterServices(config)
 				terminate(config)
 			}
 		}

--- a/src/containerbuddy/signals.go
+++ b/src/containerbuddy/signals.go
@@ -29,17 +29,16 @@ func toggleMaintenanceMode() {
 
 func terminate(config *Config) {
 	cmd := config.Command
+	if cmd == nil || cmd.Process == nil {
+		panic("cmd or cmd.Process is nil")
+	}
 	if config.StopTimeout > 0 {
-		log.Println("Send SIGTERM to application")
 		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
 			log.Printf("Error sending SIGTERM to application: %s\n", err)
 		} else {
-			log.Printf("Wait up to %d second(s) for process to end.\n", config.StopTimeout)
 			time.AfterFunc(time.Duration(config.StopTimeout)*time.Second, func() {
-				if !cmd.ProcessState.Exited() {
-					log.Printf("Killing Process %#v\n", cmd.Process)
-					cmd.Process.Kill()
-				}
+				log.Printf("Killing Process %#v\n", cmd.Process)
+				cmd.Process.Kill()
 			})
 			return
 		}

--- a/src/containerbuddy/signals_test.go
+++ b/src/containerbuddy/signals_test.go
@@ -6,18 +6,46 @@ import (
 	"runtime"
 	"syscall"
 	"testing"
+	"time"
 )
 
-func TestMaintenanceSignal(t *testing.T) {
+// Mock Discovery
+type NoopDiscoveryService struct{}
+
+func (c *NoopDiscoveryService) SendHeartbeat(service *ServiceConfig) {
+	return
+}
+
+func (c *NoopDiscoveryService) CheckForUpstreamChanges(backend *BackendConfig) bool {
+	return false
+}
+
+func (c *NoopDiscoveryService) MarkForMaintenance(service *ServiceConfig) {
+
+}
+
+func (c *NoopDiscoveryService) Deregister(service *ServiceConfig) {
+
+}
+
+// Note: We can only do handleSignals once
+// or we'll start handling signals multiple times.
+// So all the tests have to be done here.
+func TestSignals(t *testing.T) {
+
+	cmd := getCmd([]string{"/root/examples/test/test.sh", "interruptSleep"})
+	service := &ServiceConfig{Name: "test-service", Poll: 1, discoveryService: &NoopDiscoveryService{}}
+	config := &Config{Command: cmd, StopTimeout: 5, Services: []*ServiceConfig{service}}
 
 	if inMaintenanceMode() {
 		t.Errorf("Should not be in maintenance mode before starting handler")
 	}
-	handleSignals(&Config{})
+	handleSignals(config)
 	if inMaintenanceMode() {
 		t.Errorf("Should not be in maintenance mode after starting handler")
 	}
 
+	// Test SIGUSR1
 	sendAndWaitForSignal(t, syscall.SIGUSR1)
 	if !inMaintenanceMode() {
 		t.Errorf("Should be in maintenance mode after receiving SIGUSR1")
@@ -26,12 +54,38 @@ func TestMaintenanceSignal(t *testing.T) {
 	if inMaintenanceMode() {
 		t.Errorf("Should not be in maintenance mode after receiving second SIGUSR1")
 	}
+
+	// Test SIGTERM
+	startTime := time.Now()
+	quit := make(chan int, 1)
+	go func() {
+		if exitCode, _ := executeAndWait(cmd); exitCode != 2 {
+			t.Errorf("Expected exit code 0 but got %d", exitCode)
+		}
+		quit <- 1
+	}()
+	runtime.Gosched()
+	time.Sleep(10 * time.Millisecond)
+	sendSignal(t, syscall.SIGTERM)
+	<-quit
+	close(quit)
+	if elapsed := time.Since(startTime); elapsed.Seconds() > float64(config.StopTimeout) {
+		t.Errorf("Expected elapsed time <= %d seconds, but was %.2f", config.StopTimeout, elapsed.Seconds())
+	}
 }
 
 // helper to ensure that we block for the signal to deliver any signal
 // we need, and then yield execution so that the handler gets a chance
 // at running. If we don't do this there's a race where we can check
 // resulting side-effects of a handler before it's been run
+
+func sendSignal(t *testing.T, s os.Signal) {
+	me, _ := os.FindProcess(os.Getpid())
+	if err := me.Signal(s); err != nil {
+		t.Errorf("Got error on %s: %v", s.String(), err)
+	}
+}
+
 func sendAndWaitForSignal(t *testing.T, s os.Signal) {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGUSR1)

--- a/src/containerbuddy/signals_test.go
+++ b/src/containerbuddy/signals_test.go
@@ -74,11 +74,6 @@ func TestSignals(t *testing.T) {
 	}
 }
 
-// helper to ensure that we block for the signal to deliver any signal
-// we need, and then yield execution so that the handler gets a chance
-// at running. If we don't do this there's a race where we can check
-// resulting side-effects of a handler before it's been run
-
 func sendSignal(t *testing.T, s os.Signal) {
 	me, _ := os.FindProcess(os.Getpid())
 	if err := me.Signal(s); err != nil {
@@ -86,6 +81,10 @@ func sendSignal(t *testing.T, s os.Signal) {
 	}
 }
 
+// helper to ensure that we block for the signal to deliver any signal
+// we need, and then yield execution so that the handler gets a chance
+// at running. If we don't do this there's a race where we can check
+// resulting side-effects of a handler before it's been run
 func sendAndWaitForSignal(t *testing.T, s os.Signal) {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGUSR1)


### PR DESCRIPTION
## Changes

- Handle SIGTERM, send to application
- Add `stopTimeout` to config to manage wait time
- Extend DiscoveryService - add Deregister
- Deregister all services when application exits
- OnStop command to run after application exits

## Use Case

When i run my Containerbuddy images, i want them to automatically deregister from consul when they die, so that they do not clutter up the service namespace. Especially problematic when scaling these containers out with Mesos where applications may be moved around frequently.

## Notes

I'm a bit of a golang noob, so I'm not sure how to add tests for this, since this has some external effects. FWIW, I tested this empirically using a local Mesos and Consul cluster.