### PR TITLE
Fix interface configuration in nginx.json example

### DIFF
--- a/examples/nginx/opt/containerbuddy/nginx.json
+++ b/examples/nginx/opt/containerbuddy/nginx.json
@@ -4,7 +4,7 @@
     {
       "name": "nginx",
       "port": 80,
-      "interface": "eth0",
+      "interfaces": ["eth0"],
       "health": "/usr/bin/curl --fail -s http://localhost/health.txt",
       "poll": 10,
       "ttl": 25


### PR DESCRIPTION
PR to add interfaces had a bug in the example application which used the old "interface" configuration.  Example still works, but would be confusing, since it is silently ignored.