### PR TITLE
Support version flag

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 
 .PHONY: clean test consul run example ship
 
-VERSION := 0.0.2-alpha
+VERSION := 0.0.3-alpha
 ROOT := $(shell pwd)
 GO := docker run --rm --link containerbuddy_consul:consul -e CGO_ENABLED=0 -e GOPATH=/root/.godeps:/src -v ${ROOT}:/root -w /root/src/containerbuddy golang go
 
@@ -55,10 +55,10 @@ build: .godeps
 	chmod +x ${ROOT}/build/containerbuddy
 
 # create the files we need for an official release on Github
-release: build
+release:
 	mkdir -p release
 	git tag $(VERSION)
-	git push origin --tags
+	git push joyent/origin --tags
 	tar -czf release/containerbuddy-$(VERSION).tar.gz build/containerbuddy
 	@echo
 	@echo Upload this file to Github release:

--- a/makefile
+++ b/makefile
@@ -5,7 +5,9 @@ SHELL := /bin/bash
 
 .PHONY: clean test consul run example ship
 
-VERSION := 0.0.3-alpha
+VERSION ?= dev-build-not-for-release
+LDFLAGS := '-X main.GitHash=$(shell git rev-parse --short HEAD) -X main.Version=${VERSION}'
+
 ROOT := $(shell pwd)
 GO := docker run --rm --link containerbuddy_consul:consul -e CGO_ENABLED=0 -e GOPATH=/root/.godeps:/src -v ${ROOT}:/root -w /root/src/containerbuddy golang go
 
@@ -19,6 +21,7 @@ clean:
 # run unit tests and exec test
 test: .godeps consul
 	${GO} vet
+	${GO} fmt
 	${GO} test -v -coverprofile=/root/coverage.out
 	docker rm -f containerbuddy_consul || true
 
@@ -51,7 +54,7 @@ build: .godeps
 			-v ${ROOT}:/root \
 			-w /root/src/containerbuddy \
 			golang \
-			go build -a -o /root/build/containerbuddy
+			go build -a -o /root/build/containerbuddy -ldflags ${LDFLAGS}
 	chmod +x ${ROOT}/build/containerbuddy
 
 # create the files we need for an official release on Github

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -11,6 +11,11 @@ import (
 	"strings"
 )
 
+var (
+	Version string // version for this build, set at build time via LDFLAGS
+	GitHash string // short-form hash of the commit of this build, set at build time
+)
+
 type Config struct {
 	Consul      string `json:"consul,omitempty"`
 	OnStart     string `json:"onStart"`
@@ -66,10 +71,16 @@ func (s *ServiceConfig) MarkForMaintenance() {
 func loadConfig() (*Config, error) {
 
 	var configFlag string
+	var versionFlag bool
 	var discovery DiscoveryService
 	discoveryCount := 0
 	flag.StringVar(&configFlag, "config", "", "JSON config or file:// path to JSON config file.")
+	flag.BoolVar(&versionFlag, "version", false, "Show version identifier and quit.")
 	flag.Parse()
+	if versionFlag {
+		fmt.Printf("Version: %s\nGitHash: %s\n", Version, GitHash)
+		os.Exit(0)
+	}
 	if configFlag == "" {
 		configFlag = os.Getenv("CONTAINERBUDDY")
 	}


### PR DESCRIPTION
For https://github.com/joyent/containerbuddy/issues/24. Injects the version ID into the binary at build time via LDFLAGS.

This effectively reverts the [version bump](https://github.com/joyent/containerbuddy/commit/6d30643fdd2915c671bb436d9845a998961bda9b) commit as well, so we can tag the new build with the [nearly-ready PR](https://github.com/joyent/containerbuddy/pull/22) from @justenwalker for deregistering services too

cc @misterbisson 