### PR TITLE
Signal test fix

### DIFF
--- a/src/containerbuddy/signals.go
+++ b/src/containerbuddy/signals.go
@@ -74,17 +74,15 @@ func handleSignals(config *Config) {
 			case syscall.SIGUSR1:
 				toggleMaintenanceMode()
 				if inMaintenanceMode() {
-					log.Println("we are paused!")
 					forAllServices(config, func(service *ServiceConfig) {
 						log.Printf("Marking for maintenance: %s\n", service.Name)
 						service.MarkForMaintenance()
 					})
 				}
 			case syscall.SIGTERM:
-				log.Println("Caught SIGTERM")
 				stopPolling(config)
 				forAllServices(config, func(service *ServiceConfig) {
-					log.Printf("Deregister service: %s\n", service.Name)
+					log.Printf("Deregistering service: %s\n", service.Name)
 					service.Deregister()
 				})
 				terminate(config)

--- a/src/containerbuddy/signals_test.go
+++ b/src/containerbuddy/signals_test.go
@@ -12,17 +12,13 @@ import (
 // Mock Discovery
 type NoopDiscoveryService struct{}
 
-func (c *NoopDiscoveryService) SendHeartbeat(service *ServiceConfig) {
-	return
-}
-
+func (c *NoopDiscoveryService) SendHeartbeat(service *ServiceConfig) { return }
 func (c *NoopDiscoveryService) CheckForUpstreamChanges(backend *BackendConfig) bool {
 	return false
 }
 
-func (c *NoopDiscoveryService) MarkForMaintenance(service *ServiceConfig) {
-
-}
+func (c *NoopDiscoveryService) MarkForMaintenance(service *ServiceConfig) {}
+func (c *NoopDiscoveryService) Deregister(service *ServiceConfig)         {}
 
 var signalConfig *Config
 var handlerSet bool
@@ -86,8 +82,10 @@ func TestTerminateSignal(t *testing.T) {
 	sendSignal(t, syscall.SIGTERM)
 	<-quit
 	close(quit)
-	if elapsed := time.Since(startTime); elapsed.Seconds() > float64(config.StopTimeout) {
-		t.Errorf("Expected elapsed time <= %d seconds, but was %.2f", config.StopTimeout, elapsed.Seconds())
+	elapsed := time.Since(startTime)
+	if elapsed.Seconds() > float64(config.StopTimeout) {
+		t.Errorf("Expected elapsed time <= %d seconds, but was %.2f",
+			config.StopTimeout, elapsed.Seconds())
 	}
 }
 

--- a/src/containerbuddy/signals_test.go
+++ b/src/containerbuddy/signals_test.go
@@ -80,7 +80,7 @@ func TestTerminateSignal(t *testing.T) {
 	}()
 	// we need time for the forked process to start up and this is async
 	runtime.Gosched()
-	time.Sleep(1 * time.Second)
+	time.Sleep(10 * time.Millisecond)
 
 	sendSignal(t, syscall.SIGTERM)
 	<-quit

--- a/src/containerbuddy/signals_test.go
+++ b/src/containerbuddy/signals_test.go
@@ -78,8 +78,10 @@ func TestTerminateSignal(t *testing.T) {
 		}
 		quit <- 1
 	}()
+	// we need time for the forked process to start up and this is async
 	runtime.Gosched()
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(1 * time.Second)
+
 	sendSignal(t, syscall.SIGTERM)
 	<-quit
 	close(quit)
@@ -105,8 +107,7 @@ func sendAndWaitForSignal(t *testing.T, s os.Signal) {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGUSR1)
 	sendSignal(t, s)
-	runtime.Gosched()
 	<-sig
 	runtime.Gosched()
-	signal.Stop(sig)
+	time.Sleep(1 * time.Second)
 }

--- a/src/containerbuddy/signals_test.go
+++ b/src/containerbuddy/signals_test.go
@@ -36,6 +36,7 @@ func setupSignalsTests() *Config {
 			StopTimeout: 5,
 			Services:    []*ServiceConfig{service},
 		}
+		signal.Reset()
 		handleSignals(config)
 		signalConfig = config
 		handlerSet = true
@@ -103,10 +104,9 @@ func sendSignal(t *testing.T, s os.Signal) {
 func sendAndWaitForSignal(t *testing.T, s os.Signal) {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGUSR1)
-	me, _ := os.FindProcess(os.Getpid())
-	if err := me.Signal(s); err != nil {
-		t.Errorf("Got error on SIGUSR1: %v", err)
-	}
+	sendSignal(t, s)
+	runtime.Gosched()
 	<-sig
 	runtime.Gosched()
+	signal.Stop(sig)
 }


### PR DESCRIPTION
For https://github.com/joyent/containerbuddy/issues/32

Signals are asynchronous and we needed to force the test runner to wait long enough for the signal to propagate in order to guarantee that the test would pass on all platforms. In the process of debugging this, I've refactored the signal setup process so as to reduce the confusion around set up and teardown of the signal handlers.

ref https://travis-ci.org/tgross/containerbuddy/builds/94976042 for a passing build
cc @justenwalker and @misterbisson 