### PR TITLE
Fix race condition with signal handling

### DIFF
--- a/src/containerbuddy/signals.go
+++ b/src/containerbuddy/signals.go
@@ -12,6 +12,9 @@ import (
 // globals are eeeeevil
 var paused bool
 var pauseLock = sync.RWMutex{}
+var signalsChannel = setupSignalHandling()
+var signalsHandled bool
+var signalsHandledQuit = make(chan int, 1)
 
 // we wrap access to `paused` in a RLock so that if we're in the middle of
 // marking services for maintenance we don't get stale reads
@@ -21,10 +24,17 @@ func inMaintenanceMode() bool {
 	return paused
 }
 
-func toggleMaintenanceMode() {
+func toggleMaintenanceMode(config *Config) {
 	pauseLock.Lock()
 	defer pauseLock.Unlock()
 	paused = !paused
+	if paused {
+		//log.Println("we are paused!")
+		forAllServices(config, func(service *ServiceConfig) {
+			log.Printf("Marking for maintenance: %s\n", service.Name)
+			service.MarkForMaintenance()
+		})
+	}
 }
 
 func terminate(config *Config) {
@@ -62,24 +72,34 @@ func forAllServices(config *Config, fn serviceFunc) {
 	}
 }
 
+// SIGKILL is never sent to the app
+// so we can safely use it as a poison pill to quit the goroutine
+func stopSignals() {
+	if signalsHandled == true {
+		signalsChannel <- syscall.SIGKILL
+		<-signalsHandledQuit
+	}
+}
+
 // Listen for and capture signals from the OS
-func handleSignals(config *Config) {
+func setupSignalHandling() chan os.Signal {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGUSR1, syscall.SIGTERM)
+	return sig
+}
+
+// Handle signals with the given config
+// Multiple calls will overwite previous ones
+func handleSignals(config *Config) {
+	stopSignals()
+	signalsHandled = true
 	go func() {
-		for signal := range sig {
+		for signal := range signalsChannel {
 			switch signal {
 			// there's only one handler today but this makes it obvious
 			// where to add support for new signals
 			case syscall.SIGUSR1:
-				toggleMaintenanceMode()
-				if inMaintenanceMode() {
-					log.Println("we are paused!")
-					forAllServices(config, func(service *ServiceConfig) {
-						log.Printf("Marking for maintenance: %s\n", service.Name)
-						service.MarkForMaintenance()
-					})
-				}
+				toggleMaintenanceMode(config)
 			case syscall.SIGTERM:
 				log.Println("Caught SIGTERM")
 				stopPolling(config)
@@ -88,6 +108,10 @@ func handleSignals(config *Config) {
 					service.Deregister()
 				})
 				terminate(config)
+			case syscall.SIGKILL: //Poison Pill
+				signalsHandled = false
+				signalsHandledQuit <- 1
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
Fixes #32

- Adds a sleep to force signal handling to execute
- Fixes potential CTA concurrency issue
- handleSignals will deregister previous handlers - making testing easier