### PR TITLE
Add support for command args with JSON Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Service fields:
 - `name` is the name of the service as it will appear in Consul. Each instance of the service will have a unique ID made up from `name`+hostname of the container.
 - `port` is the port the service will advertise to Consul.
 - `health` is the executable (and its arguments) used to check the health of the service.
-- `interfaces` is an optional array of interfaces in priority order. If given, the IP of the service will be obtained from the first interface found that matches a name in this list. (Default value is `["eth0"]`)
+- `interfaces` is an optional single interface name or array of interfaces in priority order. If given, the IP of the service will be obtained from the first interface that exits in the container. (Default value is `["eth0"]`)
 - `poll` is the time in seconds between polling for health checks.
 - `ttl` is the time-to-live of a successful health check. This should be longer than the polling rate so that the polling process and the TTL aren't racing; otherwise Consul will mark the service as unhealthy.
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,15 @@ The format of the JSON file configuration is as follows:
     {
       "name": "app",
       "port": 80,
-      "health": "/usr/bin/curl --fail -s http://localhost/app",
-      "interfaces": ["eth0"],
+      "health": [
+        "/usr/bin/curl",
+        "--fail",
+        "-s",
+        "http://localhost/app"
+      ],
+      "interfaces": [
+        "eth0"
+      ],
       "poll": 10,
       "ttl": 30
     }
@@ -97,6 +104,27 @@ Other fields:
 - `stopTimeout` Optional amount of time in seconds to wait before killing the application. (defaults to `5`). Providing `-1` will kill the application immediately.
 
 *Note that if you're using `curl` to check HTTP endpoints for health checks, that it doesn't return a non-zero exit code on 404s or similar failure modes by default. Use the `--fail` flag for curl if you need to catch those cases.*
+
+#### Commands & arguments
+
+All executable fields, such as `onStart` and `onChange`, accept both a string or an array. If a string is given, the command and its arguments are separated by spaces; otherwise, the first element of the array is the command path, and the rest are its arguments.
+
+**String Command**
+
+```json
+"health": "/usr/bin/curl --fail -s http://localhost/app"
+```
+
+**Array Command**
+
+```json
+"health": [
+  "/usr/bin/curl",
+  "--fail",
+  "-s",
+  "http://localhost/app"
+]
+```
 
 ### Operating Containerbuddy
 

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -281,3 +281,21 @@ func getInterfaceIps() []InterfaceIp {
 	}
 	return ifaceIps
 }
+
+func argsToCmd(args []string) *exec.Cmd {
+	if len(args) == 0 {
+		return nil
+	}
+	if len(args) > 1 {
+		return exec.Command(args[0], args[1:]...)
+	} else {
+		return exec.Command(args[0])
+	}
+}
+
+func strToCmd(command string) *exec.Cmd {
+	if command != "" {
+		return argsToCmd(strings.Split(command, " "))
+	}
+	return nil
+}

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -87,7 +87,7 @@ const (
 
 func parseInterfaces(raw json.RawMessage) ([]string, error) {
 	if raw == nil {
-		return nil, nil
+		return []string{}, nil
 	}
 	// Parse as a string
 	var jsonString string
@@ -100,7 +100,7 @@ func parseInterfaces(raw json.RawMessage) ([]string, error) {
 		return jsonArray, nil
 	}
 
-	return nil, errors.New("interfaces must be a string or an array")
+	return []string{}, errors.New("interfaces must be a string or an array")
 }
 
 func parseCommandArgs(raw json.RawMessage) (*exec.Cmd, error) {

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -144,19 +144,19 @@ func loadConfig() (*Config, error) {
 
 	onStartCmd, err := parseCommandArgs(config.OnStart)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Could not parse `onStart`: %s", err.Error()))
+		return nil, fmt.Errorf("Could not parse `onStart`: %s", err)
 	}
 	config.onStartCmd = onStartCmd
 
 	preStopCmd, err := parseCommandArgs(config.PreStop)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Could not parse `preStop`: %s", err.Error()))
+		return nil, fmt.Errorf("Could not parse `preStop`: %s", err)
 	}
 	config.preStopCmd = preStopCmd
 
 	postStopCmd, err := parseCommandArgs(config.PostStop)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Could not parse `postStop`: %s", err.Error()))
+		return nil, fmt.Errorf("Could not parse `postStop`: %s", err)
 	}
 	config.postStopCmd = postStopCmd
 
@@ -183,7 +183,8 @@ func loadConfig() (*Config, error) {
 	for _, backend := range config.Backends {
 		cmd, err := parseCommandArgs(backend.OnChangeExec)
 		if err != nil {
-			return nil, errors.New(fmt.Sprintf("Could not parse `onChange` in backend %s: %s", backend.Name, err.Error()))
+			return nil, fmt.Errorf("Could not parse `onChange` in backend %s: %s",
+				backend.Name, err)
 		}
 		backend.onChangeCmd = cmd
 		backend.discoveryService = discovery
@@ -195,7 +196,8 @@ func loadConfig() (*Config, error) {
 		service.discoveryService = discovery
 
 		if cmd, err := parseCommandArgs(service.HealthCheckExec); err != nil {
-			return nil, errors.New(fmt.Sprintf("Could not parse `health` in service %s: %s", service.Name, err.Error()))
+			return nil, fmt.Errorf("Could not parse `health` in service %s: %s",
+				service.Name, err)
 		} else {
 			service.healthCheckCmd = cmd
 		}

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -18,35 +18,40 @@ var (
 )
 
 type Config struct {
-	Consul       string `json:"consul,omitempty"`
-	OnStart      string `json:"onStart"`
-	PreStop      string `json:"preStop"`
-	PostStop     string `json:"postStop"`
-	StopTimeout  int    `json:"stopTimeout"`
-	Command      *exec.Cmd
-	QuitChannels []chan bool
+	Consul       string           `json:"consul,omitempty"`
+	OnStart      json.RawMessage  `json:"onStart,omitempty"`
+	PreStop      json.RawMessage  `json:"preStop,omitempty"`
+	PostStop     json.RawMessage  `json:"postStop,omitempty"`
+	StopTimeout  int              `json:"stopTimeout"`
 	Services     []*ServiceConfig `json:"services"`
 	Backends     []*BackendConfig `json:"backends"`
+	onStartCmd   *exec.Cmd
+	preStopCmd   *exec.Cmd
+	postStopCmd  *exec.Cmd
+	Command      *exec.Cmd
+	QuitChannels []chan bool
 }
 
 type ServiceConfig struct {
 	Id               string
-	Name             string   `json:"name"`
-	Poll             int      `json:"poll"` // time in seconds
-	HealthCheckExec  string   `json:"health"`
-	Port             int      `json:"port"`
-	TTL              int      `json:"ttl"`
-	Interfaces       []string `json:"interfaces"`
+	Name             string          `json:"name"`
+	Poll             int             `json:"poll"` // time in seconds
+	HealthCheckExec  json.RawMessage `json:"health"`
+	Port             int             `json:"port"`
+	TTL              int             `json:"ttl"`
+	Interfaces       []string        `json:"interfaces"`
 	discoveryService DiscoveryService
 	ipAddress        string
+	healthCheckCmd   *exec.Cmd
 }
 
 type BackendConfig struct {
-	Name             string `json:"name"`
-	Poll             int    `json:"poll"` // time in seconds
-	OnChangeExec     string `json:"onChange"`
+	Name             string          `json:"name"`
+	Poll             int             `json:"poll"` // time in seconds
+	OnChangeExec     json.RawMessage `json:"onChange"`
 	discoveryService DiscoveryService
 	lastState        interface{}
+	onChangeCmd      *exec.Cmd
 }
 
 type Pollable interface {
@@ -80,6 +85,23 @@ const (
 	defaultStopTimeout int = 5
 )
 
+func parseCommandArgs(raw json.RawMessage) (*exec.Cmd, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	// Parse as a string
+	var stringCmd string
+	if err := json.Unmarshal(raw, &stringCmd); err == nil {
+		return strToCmd(stringCmd), nil
+	}
+
+	var arrayCmd []string
+	if err := json.Unmarshal(raw, &arrayCmd); err == nil {
+		return argsToCmd(arrayCmd), nil
+	}
+	return nil, errors.New("Command argument must be a string or an array")
+}
+
 func loadConfig() (*Config, error) {
 
 	var configFlag string
@@ -102,6 +124,24 @@ func loadConfig() (*Config, error) {
 		return nil, err
 	}
 
+	onStartCmd, err := parseCommandArgs(config.OnStart)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Could not parse `onStart`: %s", err.Error()))
+	}
+	config.onStartCmd = onStartCmd
+
+	preStopCmd, err := parseCommandArgs(config.PreStop)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Could not parse `preStop`: %s", err.Error()))
+	}
+	config.preStopCmd = preStopCmd
+
+	postStopCmd, err := parseCommandArgs(config.PostStop)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Could not parse `postStop`: %s", err.Error()))
+	}
+	config.postStopCmd = postStopCmd
+
 	for _, discoveryBackend := range []string{"Consul"} {
 		switch discoveryBackend {
 		case "Consul":
@@ -123,6 +163,11 @@ func loadConfig() (*Config, error) {
 	}
 
 	for _, backend := range config.Backends {
+		cmd, err := parseCommandArgs(backend.OnChangeExec)
+		if err != nil {
+			return nil, errors.New(fmt.Sprintf("Could not parse `onChange` in backend %s: %s", backend.Name, err.Error()))
+		}
+		backend.onChangeCmd = cmd
 		backend.discoveryService = discovery
 	}
 
@@ -130,6 +175,13 @@ func loadConfig() (*Config, error) {
 	for _, service := range config.Services {
 		service.Id = fmt.Sprintf("%s-%s", service.Name, hostname)
 		service.discoveryService = discovery
+
+		cmd, err := parseCommandArgs(service.HealthCheckExec)
+		if err != nil {
+			return nil, errors.New(fmt.Sprintf("Could not parse `health` in service %s: %s", service.Name, err.Error()))
+		}
+		service.healthCheckCmd = cmd
+
 		if service.ipAddress, err = getIp(service.Interfaces); err != nil {
 			return nil, err
 		}

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -72,22 +72,24 @@ func TestValidConfigParse(t *testing.T) {
 func TestParseInterfaces(t *testing.T) {
 	if interfaces, err := parseInterfaces(nil); err != nil {
 		t.Errorf("Unexpected parse error: %s", err.Error())
-	} else if interfaces != nil {
+	} else if len(interfaces) > 0 {
 		t.Errorf("Expected no interfaces, but got %s", interfaces)
 	}
 
 	json1 := json.RawMessage(`"eth0"`)
+	expected1 := []string{"eth0"}
 	if interfaces, err := parseInterfaces(json1); err != nil {
 		t.Errorf("Unexpected parse error: %s", err.Error())
-	} else if !reflect.DeepEqual(interfaces, []string{"eth0"}) {
-		t.Errorf("Expected 1 interface, got: %s", interfaces)
+	} else if !reflect.DeepEqual(interfaces, expected1) {
+		t.Errorf("Expected %s, got: %s", expected1, interfaces)
 	}
 
 	json2 := json.RawMessage(`["ethwe","eth0"]`)
+	expected2 := []string{"ethwe", "eth0"}
 	if interfaces, err := parseInterfaces(json2); err != nil {
 		t.Errorf("Unexpected parse error: %s", err.Error())
-	} else if !reflect.DeepEqual(interfaces, []string{"ethwe", "eth0"}) {
-		t.Errorf("Expected 2 interfaces, got: %s", interfaces)
+	} else if !reflect.DeepEqual(interfaces, expected2) {
+		t.Errorf("Expected %s, got: %s", expected2, interfaces)
 	}
 
 	json3 := json.RawMessage(`{ "a": true }`)

--- a/src/containerbuddy/main.go
+++ b/src/containerbuddy/main.go
@@ -18,7 +18,7 @@ func main() {
 	}
 
 	// Run the onStart handler, if any, and exit if it returns an error
-	if onStartCode, err := run(config.OnStart); err != nil {
+	if onStartCode, err := run(config.onStartCmd); err != nil {
 		os.Exit(onStartCode)
 	}
 
@@ -27,10 +27,10 @@ func main() {
 
 	var quit []chan bool
 	for _, backend := range config.Backends {
-		quit = append(quit, poll(backend, checkForChanges, backend.OnChangeExec))
+		quit = append(quit, poll(backend, checkForChanges))
 	}
 	for _, service := range config.Services {
-		quit = append(quit, poll(service, checkHealth, service.HealthCheckExec))
+		quit = append(quit, poll(service, checkHealth))
 	}
 	config.QuitChannels = quit
 
@@ -46,13 +46,13 @@ func main() {
 		// Run our main application and capture its stdout/stderr.
 		// This will block until the main application exits and then os.Exit
 		// with the exit code of that application.
-		config.Command = getCmd(flag.Args())
+		config.Command = argsToCmd(flag.Args())
 		code, err := executeAndWait(config.Command)
 		if err != nil {
 			log.Println(err)
 		}
 		// Run the PostStop handler, if any, and exit if it returns an error
-		if postStopCode, err := run(config.PostStop); err != nil {
+		if postStopCode, err := run(config.postStopCmd); err != nil {
 			os.Exit(postStopCode)
 		}
 		os.Exit(code)
@@ -63,11 +63,11 @@ func main() {
 	select {}
 }
 
-type pollingFunc func(Pollable, string)
+type pollingFunc func(Pollable)
 
 // Every `pollTime` seconds, run the `pollingFunc` function.
 // Expect a bool on the quit channel to stop gracefully.
-func poll(config Pollable, fn pollingFunc, command string) chan bool {
+func poll(config Pollable, fn pollingFunc) chan bool {
 	ticker := time.NewTicker(time.Duration(config.PollTime()) * time.Second)
 	quit := make(chan bool)
 	go func() {
@@ -75,7 +75,7 @@ func poll(config Pollable, fn pollingFunc, command string) chan bool {
 			select {
 			case <-ticker.C:
 				if !inMaintenanceMode() {
-					fn(config, command)
+					fn(config)
 				}
 			case <-quit:
 				return
@@ -88,23 +88,26 @@ func poll(config Pollable, fn pollingFunc, command string) chan bool {
 // Implements `pollingFunc`; args are the executable we use to check the
 // application health and its arguments. If the error code on that exectable is
 // 0, we write a TTL health check to the health check store.
-func checkHealth(pollable Pollable, command string) {
+func checkHealth(pollable Pollable) {
 	service := pollable.(*ServiceConfig) // if we pass a bad type here we crash intentionally
-	if code, _ := run(command); code == 0 {
+	if code, _ := run(service.healthCheckCmd); code == 0 {
 		service.SendHeartbeat()
 	}
 }
 
 // Implements `pollingFunc`; args are the executable we run if the values in
 // the central store have changed since the last run.
-func checkForChanges(pollable Pollable, command string) {
+func checkForChanges(pollable Pollable) {
 	backend := pollable.(*BackendConfig) // if we pass a bad type here we crash intentionally
 	if backend.CheckForUpstreamChanges() {
-		run(command)
+		run(backend.onChangeCmd)
 	}
 }
 
-func getCmd(args []string) *exec.Cmd {
+func argsToCmd(args []string) *exec.Cmd {
+	if len(args) == 0 {
+		return nil
+	}
 	if len(args) > 1 {
 		return exec.Command(args[0], args[1:]...)
 	} else {
@@ -112,8 +115,18 @@ func getCmd(args []string) *exec.Cmd {
 	}
 }
 
+func strToCmd(command string) *exec.Cmd {
+	if command != "" {
+		return argsToCmd(strings.Split(command, " "))
+	}
+	return nil
+}
+
 // Executes the given command and blocks until completed
 func executeAndWait(cmd *exec.Cmd) (int, error) {
+	if cmd == nil {
+		return 0, nil
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -128,16 +141,13 @@ func executeAndWait(cmd *exec.Cmd) (int, error) {
 	return 0, nil
 }
 
-// Runs an arbitrary string of arguments as an executable and its arguments.
+// Executes the given command and blocks until completed
 // Returns the exit code and error message (if any).
-func run(command string) (int, error) {
-	if command != "" {
-		args := strings.Split(command, " ")
-		code, err := executeAndWait(getCmd(args))
-		if err != nil {
-			log.Println(err)
-		}
-		return code, err
+// Logs errors
+func run(cmd *exec.Cmd) (int, error) {
+	code, err := executeAndWait(cmd)
+	if err != nil {
+		log.Println(err)
 	}
-	return 0, nil
+	return code, err
 }

--- a/src/containerbuddy/main.go
+++ b/src/containerbuddy/main.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"strings"
 	"syscall"
 	"time"
 )
@@ -102,24 +101,6 @@ func checkForChanges(pollable Pollable) {
 	if backend.CheckForUpstreamChanges() {
 		run(backend.onChangeCmd)
 	}
-}
-
-func argsToCmd(args []string) *exec.Cmd {
-	if len(args) == 0 {
-		return nil
-	}
-	if len(args) > 1 {
-		return exec.Command(args[0], args[1:]...)
-	} else {
-		return exec.Command(args[0])
-	}
-}
-
-func strToCmd(command string) *exec.Cmd {
-	if command != "" {
-		return argsToCmd(strings.Split(command, " "))
-	}
-	return nil
 }
 
 // Executes the given command and blocks until completed

--- a/src/containerbuddy/signals.go
+++ b/src/containerbuddy/signals.go
@@ -43,7 +43,7 @@ func terminate(config *Config) {
 	})
 
 	// Run and wait for preStop command to exit
-	run(config.PreStop)
+	run(config.preStopCmd)
 
 	cmd := config.Command
 	if cmd == nil || cmd.Process == nil {

--- a/src/containerbuddy/signals_test.go
+++ b/src/containerbuddy/signals_test.go
@@ -25,7 +25,7 @@ func (c *NoopDiscoveryService) Deregister(service *ServiceConfig)         {}
 
 func getSignalTestConfig() *Config {
 	config := &Config{
-		Command: getCmd([]string{
+		Command: argsToCmd([]string{
 			"/root/examples/test/test.sh",
 			"interruptSleep"}),
 		StopTimeout: 5,


### PR DESCRIPTION
See [README.md](https://github.com/justenwalker/containerbuddy/blob/array-args/README.md) for a [better description](https://github.com/justenwalker/containerbuddy/blob/array-args/README.md#commands--arguments)

- Refactor getCmd into argsToCmd and strToCmd
- Add *Cmd parameters to all config structs
- Add parseCommandArgs function which supports JSON array or JSON string
- Support parsing interfaces as a string with parseInterfaces
- Do parsing of all commands once - during loadConfig()
- Update README

For #37