### PR TITLE
Remove dead code, readability cleanup

### DIFF
--- a/makefile
+++ b/makefile
@@ -69,6 +69,7 @@ build: .godeps
 			go build -a -o /root/build/containerbuddy -ldflags ${LDFLAGS}
 	chmod +x ${ROOT}/build/containerbuddy
 endif
+
 # create the files we need for an official release on Github
 # run this target with the VERSION environment variable set
 release: build ship


### PR DESCRIPTION
This PR is some minor cleanup:
- Removes the `isPublicIp` function that became unused after https://github.com/joyent/containerbuddy/issues/20 landed. (This also improves line coverage % of our tests.)
- Moves definition of `getInterfaceIps` after its caller for straight-line reading.
- Breaks up a couple 80+ long lines.

cc @misterbisson or @justenwalker to take a quick look.