### PR TITLE
Refresh exec.Cmd for Health and OnChange

### DIFF
--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -65,6 +65,13 @@ func (b *BackendConfig) CheckForUpstreamChanges() bool {
 	return b.discoveryService.CheckForUpstreamChanges(b)
 }
 
+func (b *BackendConfig) OnChange() (int, error) {
+	exitCode, err := run(b.onChangeCmd)
+	// Reset command object - since it can't be reused
+	b.onChangeCmd = argsToCmd(b.onChangeCmd.Args)
+	return exitCode, err
+}
+
 func (s ServiceConfig) PollTime() int {
 	return s.Poll
 }
@@ -78,6 +85,13 @@ func (s *ServiceConfig) MarkForMaintenance() {
 
 func (s *ServiceConfig) Deregister() {
 	s.discoveryService.Deregister(s)
+}
+
+func (s *ServiceConfig) CheckHealth() (int, error) {
+	exitCode, err := run(s.healthCheckCmd)
+	// Reset command object - since it can't be reused
+	s.healthCheckCmd = argsToCmd(s.healthCheckCmd.Args)
+	return exitCode, err
 }
 
 const (

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -191,6 +191,34 @@ func TestGetIp(t *testing.T) {
 	}
 }
 
+func TestOnChangeCmd(t *testing.T) {
+	cmd1 := strToCmd("/root/examples/test/test.sh doStuff --debug")
+	backend := &BackendConfig{
+		onChangeCmd: cmd1,
+	}
+	if _, err := backend.OnChange(); err != nil {
+		t.Errorf("Unexpected error OnChange: %s", err)
+	}
+	// Ensure we can run it more than once
+	if _, err := backend.OnChange(); err != nil {
+		t.Errorf("Unexpected error OnChange (x2): %s", err)
+	}
+}
+
+func TestHealthCheck(t *testing.T) {
+	cmd1 := strToCmd("/root/examples/test/test.sh doStuff --debug")
+	service := &ServiceConfig{
+		healthCheckCmd: cmd1,
+	}
+	if _, err := service.CheckHealth(); err != nil {
+		t.Errorf("Unexpected error CheckHealth: %s", err)
+	}
+	// Ensure we can run it more than once
+	if _, err := service.CheckHealth(); err != nil {
+		t.Errorf("Unexpected error CheckHealth (x2): %s", err)
+	}
+}
+
 // ----------------------------------------------------
 // test helpers
 

--- a/src/containerbuddy/main.go
+++ b/src/containerbuddy/main.go
@@ -89,7 +89,7 @@ func poll(config Pollable, fn pollingFunc) chan bool {
 // 0, we write a TTL health check to the health check store.
 func checkHealth(pollable Pollable) {
 	service := pollable.(*ServiceConfig) // if we pass a bad type here we crash intentionally
-	if code, _ := run(service.healthCheckCmd); code == 0 {
+	if code, _ := service.CheckHealth(); code == 0 {
 		service.SendHeartbeat()
 	}
 }
@@ -99,7 +99,7 @@ func checkHealth(pollable Pollable) {
 func checkForChanges(pollable Pollable) {
 	backend := pollable.(*BackendConfig) // if we pass a bad type here we crash intentionally
 	if backend.CheckForUpstreamChanges() {
-		run(backend.onChangeCmd)
+		backend.OnChange()
 	}
 }
 


### PR DESCRIPTION
exec.Cmd can only be run once. Introduce two new methods, one on
ServiceConfig and one on BackendConfig that encapsulates running the
command and creating a new exec.Cmd object for subsequent runs.

Fixes #40