### PR TITLE
Add support for templates in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The format of the JSON file configuration is as follows:
 ```json
 {
   "consul": "consul:8500",
-  "onStart": "/opt/containerbuddy/onStart-script.sh",
+  "onStart": "/opt/containerbuddy/onStart-script.sh {{.ENV_VAR_NAME}}",
   "stopTimeout": 5,
   "preStop": "/opt/containerbuddy/preStop-script.sh",
   "postStop": "/opt/containerbuddy/postStop-script.sh",
@@ -124,6 +124,22 @@ All executable fields, such as `onStart` and `onChange`, accept both a string or
   "-s",
   "http://localhost/app"
 ]
+```
+
+### Template Configuration
+
+Containerbuddy configuration has template support, such as substituting environment variables in the config file. This makes it possible to use the same configuration and alter the behavior per environment. Full documentation about the template language used can be found in the [Go text/template Docs](https://golang.org/pkg/text/template/).
+
+**Example**
+
+```json
+{
+  "consul": "consul:8500",
+  "onStart": "/opt/containerbuddy/onStart-script.sh {{.URL_TO_SERVICE}} {{.API_KEY}}",
+
+  ...
+
+}
 ```
 
 ### Operating Containerbuddy

--- a/README.md
+++ b/README.md
@@ -128,19 +128,18 @@ All executable fields, such as `onStart` and `onChange`, accept both a string or
 
 ### Template Configuration
 
-Containerbuddy configuration has template support, such as substituting environment variables in the config file. This makes it possible to use the same configuration and alter the behavior per environment. Full documentation about the template language used can be found in the [Go text/template Docs](https://golang.org/pkg/text/template/).
+Containerbuddy configuration has template support. If you have an environment variable such as `FOO=BAR` then you can use `{{.FOO}}` in your configuration file and it will be substituted with `BAR`.
 
-**Example**
+**Example Usage**
 
 ```json
 {
   "consul": "consul:8500",
   "onStart": "/opt/containerbuddy/onStart-script.sh {{.URL_TO_SERVICE}} {{.API_KEY}}",
-
-  ...
-
 }
 ```
+
+_Note:  If you need more than just variable interpolation, check out the [Go text/template Docs](https://golang.org/pkg/text/template/)._
 
 ### Operating Containerbuddy
 

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -303,6 +303,11 @@ func unmarshalConfig(data []byte) (*Config, error) {
 	return config, nil
 }
 
+func newJSONParseError(js []byte, syntax *json.SyntaxError) error {
+	line, col, err := highlightError(js, syntax.Offset)
+	return fmt.Errorf("Parse error at line:col [%d:%d]: %s\n%s", line, col, syntax, err)
+}
+
 func highlightError(data []byte, pos int64) (int, int, string) {
 	prevLine := ""
 	thisLine := ""
@@ -329,11 +334,6 @@ func highlightError(data []byte, pos int64) (int, int, string) {
 		line++
 	}
 	return line, int(col), fmt.Sprintf("%s%s%s", prevLine, thisLine, highlight)
-}
-
-func newJSONParseError(js []byte, syntax *json.SyntaxError) error {
-	line, col, err := highlightError(js, syntax.Offset)
-	return fmt.Errorf("Parse error at line:col [%d:%d]: %s\n%s", line, col, syntax, err)
 }
 
 // determine the IP address of the container

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -271,12 +271,19 @@ func parseConfig(configFlag string) (*Config, error) {
 		var err error
 		fName := strings.SplitAfter(configFlag, "file://")[1]
 		if data, err = ioutil.ReadFile(fName); err != nil {
-			return nil, errors.New(
-				fmt.Sprintf("Could not read config file: %s", err))
+			return nil, fmt.Errorf("Could not read config file: %s", err)
 		}
 	} else {
 		data = []byte(configFlag)
 	}
+
+	if template, err := ApplyTemplate(data); err != nil {
+		return nil, fmt.Errorf(
+			"Could not apply template to config: %s", err)
+	} else {
+		data = template
+	}
+
 	return unmarshalConfig(data)
 }
 
@@ -345,7 +352,7 @@ func argsToCmd(args []string) *exec.Cmd {
 
 func strToCmd(command string) *exec.Cmd {
 	if command != "" {
-		return argsToCmd(strings.Split(command, " "))
+		return argsToCmd(strings.Split(strings.TrimSpace(command), " "))
 	}
 	return nil
 }

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -323,9 +323,6 @@ func highlightError(data []byte, pos int64) (int, int, string) {
 		thisLine = fmt.Sprintf("%5d: %s\n", line, scanner.Text())
 		readBytes := int64(len(scanner.Bytes()))
 		offset += readBytes
-		if offset == pos-1 {
-			col = readBytes
-		}
 		if offset >= pos-1 {
 			highlight = fmt.Sprintf("%s^", strings.Repeat("-", int(7+col-1)))
 			break

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -37,12 +37,12 @@ var testJson = `{
 			{
 					"name": "upstreamA",
 					"poll": 11,
-					"onChange": "/bin/to/onChangeEvent/for/upstream/A.sh"
+					"onChange": "/bin/to/onChangeEvent/for/upstream/A.sh {{.TEST}}"
 			},
 			{
 					"name": "upstreamB",
 					"poll": 79,
-					"onChange": "/bin/to/onChangeEvent/for/upstream/B.sh"
+					"onChange": "/bin/to/onChangeEvent/for/upstream/B.sh {{.ENV_NOT_FOUND}}"
 			}
 	]
 }
@@ -51,6 +51,7 @@ var testJson = `{
 func TestValidConfigParse(t *testing.T) {
 	defer argTestCleanup(argTestSetup())
 
+	os.Setenv("TEST", "HELLO")
 	os.Args = []string{"this", "-config", testJson, "/test.sh", "valid1", "--debug"}
 	config, _ := loadConfig()
 
@@ -67,7 +68,7 @@ func TestValidConfigParse(t *testing.T) {
 	validateCommandParsed(t, "postStop", config.postStopCmd, []string{"/bin/to/postStop.sh"})
 	validateCommandParsed(t, "health", config.Services[0].healthCheckCmd, []string{"/bin/to/healthcheck/for/service/A.sh"})
 	validateCommandParsed(t, "health", config.Services[1].healthCheckCmd, []string{"/bin/to/healthcheck/for/service/B.sh"})
-	validateCommandParsed(t, "onChange", config.Backends[0].onChangeCmd, []string{"/bin/to/onChangeEvent/for/upstream/A.sh"})
+	validateCommandParsed(t, "onChange", config.Backends[0].onChangeCmd, []string{"/bin/to/onChangeEvent/for/upstream/A.sh", "HELLO"})
 	validateCommandParsed(t, "onChange", config.Backends[1].onChangeCmd, []string{"/bin/to/onChangeEvent/for/upstream/B.sh"})
 }
 

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -170,7 +170,29 @@ func TestInvalidConfigParseFile(t *testing.T) {
 func TestInvalidConfigParseNotJson(t *testing.T) {
 	defer argTestCleanup(argTestSetup())
 	testParseExpectError(t, "<>",
-		"Could not parse configuration: invalid character '<' looking for beginning of value")
+		"Parse error at line:col [1:1]")
+}
+
+func TestJsonTemplateParseError(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	testParseExpectError(t,
+		`{
+    "test": {{ .NO_SUCH_KEY }},
+    "test2": "hello"
+}`,
+		"Parse error at line:col [2:13]")
+}
+
+func TestJsonTemplateParseError2(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	testParseExpectError(t,
+		`{
+    "test1": "1",
+    "test2": 2,
+    "test3": false,
+    test2: "hello"
+}`,
+		"Parse error at line:col [5:5]")
 }
 
 func TestGetIp(t *testing.T) {
@@ -295,7 +317,7 @@ func argTestCleanup(oldArgs []string) {
 
 func testParseExpectError(t *testing.T, testJson string, expected string) {
 	os.Args = []string{"this", "-config", testJson, "/test.sh", "test", "--debug"}
-	if _, err := loadConfig(); err != nil && err.Error() != expected {
+	if _, err := loadConfig(); err != nil && !strings.Contains(err.Error(), expected) {
 		t.Errorf("Expected %s but got %s", expected, err)
 	}
 }

--- a/src/containerbuddy/template.go
+++ b/src/containerbuddy/template.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	//"log"
-	//"fmt"
 	"bytes"
+	"fmt"
 	"os"
 	"strings"
 	"text/template"
@@ -28,10 +27,25 @@ type ConfigTemplate struct {
 	Env      Environment
 }
 
+func defaultValue(defaultValue, templateValue interface{}) string {
+	if templateValue != nil {
+		if str, ok := templateValue.(string); ok && str != "" {
+			return str
+		}
+	}
+	if defaultStr, ok := defaultValue.(string); !ok {
+		return fmt.Sprintf("%v", defaultValue)
+	} else {
+		return defaultStr
+	}
+}
+
 // Interpolate variables
 func NewConfigTemplate(config []byte) (*ConfigTemplate, error) {
 	env := parseEnvironment(os.Environ())
-	tmpl, err := template.New("").Option("missingkey=zero").Parse(string(config))
+	tmpl, err := template.New("").Funcs(template.FuncMap{
+		"default": defaultValue,
+	}).Option("missingkey=zero").Parse(string(config))
 	if err != nil {
 		return nil, err
 	}

--- a/src/containerbuddy/template.go
+++ b/src/containerbuddy/template.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	//"log"
+	//"fmt"
+	"bytes"
+	"os"
+	"strings"
+	"text/template"
+)
+
+type Environment map[string]string
+
+func parseEnvironment(environ []string) Environment {
+	env := make(Environment)
+	if len(environ) == 0 {
+		return env
+	}
+	for _, e := range environ {
+		kv := strings.Split(e, "=")
+		env[kv[0]] = kv[1]
+	}
+	return env
+}
+
+type ConfigTemplate struct {
+	Template *template.Template
+	Env      Environment
+}
+
+// Interpolate variables
+func NewConfigTemplate(config []byte) (*ConfigTemplate, error) {
+	env := parseEnvironment(os.Environ())
+	tmpl, err := template.New("").Option("missingkey=zero").Parse(string(config))
+	if err != nil {
+		return nil, err
+	}
+	return &ConfigTemplate{
+		Env:      env,
+		Template: tmpl,
+	}, nil
+}
+
+func (c *ConfigTemplate) Execute() ([]byte, error) {
+	var buffer bytes.Buffer
+	if err := c.Template.Execute(&buffer, c.Env); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}
+
+func ApplyTemplate(config []byte) ([]byte, error) {
+	template, err := NewConfigTemplate(config)
+	if err != nil {
+		return nil, err
+	}
+	return template.Execute()
+}

--- a/src/containerbuddy/template_test.go
+++ b/src/containerbuddy/template_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseEnvironment(t *testing.T) {
+	validateParseEnvironment(t, "Empty Environment", []string{}, Environment{})
+	validateParseEnvironment(t, "Example Environment", []string{
+		"VAR1=test",
+		"VAR2=test2",
+	}, Environment{
+		"VAR1": "test",
+		"VAR2": "test2",
+	})
+}
+
+func TestTemplate(t *testing.T) {
+	env := parseEnvironment([]string{"NAME=Template", "USER=buddy"})
+	validateTemplate(t, "One var", `Hello, {{.NAME}}!`, env, "Hello, Template!")
+	validateTemplate(t, "Var undefined", `Hello, {{.NONAME}}!`, env, "Hello, !")
+}
+
+// Helper Functions
+
+func validateParseEnvironment(t *testing.T, message string, environ []string, expected Environment) {
+	if parsed := parseEnvironment(environ); !reflect.DeepEqual(expected, parsed) {
+		t.Fatalf("%s; Expected %s but got %s", message, expected, parsed)
+	}
+}
+
+func validateTemplate(t *testing.T, name string, template string, env Environment, expected string) {
+	tmpl, err := NewConfigTemplate([]byte(template))
+	if err != nil {
+		t.Fatalf("%s - Error parsing template: %s", name, err)
+	}
+	tmpl.Env = env
+	res, err2 := tmpl.Execute()
+	if err2 != nil {
+		t.Fatalf("%s - Error executing template: %s", name, err2)
+	}
+	strRes := string(res)
+	if strRes != expected {
+		t.Fatalf("%s - Expected %s but got: %s", name, expected, strRes)
+	}
+}

--- a/src/containerbuddy/template_test.go
+++ b/src/containerbuddy/template_test.go
@@ -20,6 +20,9 @@ func TestTemplate(t *testing.T) {
 	env := parseEnvironment([]string{"NAME=Template", "USER=buddy"})
 	validateTemplate(t, "One var", `Hello, {{.NAME}}!`, env, "Hello, Template!")
 	validateTemplate(t, "Var undefined", `Hello, {{.NONAME}}!`, env, "Hello, !")
+	validateTemplate(t, "Default", `Hello, {{.NONAME | default "World" }}!`, env, "Hello, World!")
+	validateTemplate(t, "Default", `Hello, {{.NONAME | default 100 }}!`, env, "Hello, 100!")
+	validateTemplate(t, "Default", `Hello, {{.NONAME | default 10.1 }}!`, env, "Hello, 10.1!")
 }
 
 // Helper Functions


### PR DESCRIPTION
This is my first pass at supporting templates in configurations:

- Config is parsed as a Go template before being unmarshaled from JSON.
- Environment variables are available for interpolation. ie: `{{ .ENV_VAR_NAME }}`

For #16 
