### PR TITLE
Support configuration reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Containerbuddy accepts POSIX signals to change its runtime behavior. Currently, 
 
 - `SIGUSR1` will cause Containerbuddy to mark its advertised service for maintenance. Containerbuddy will stop sending heartbeat messages to the discovery service. The discovery service backend's `MarkForMaintenance` method will also be called (in the default Consul implementation, this deregisters the node from Consul).
 - `SIGTERM` will cause Containerbuddy to send `SIGTERM` to the application, and eventually exit in a timely manner (as specified by `stopTimeout`).
+- `SIGHUP` will cause Containerbuddy to reload its configuration. `onChange`, `health`, `preStop`, and `postStop` handlers will operate with the new configuration. This forces all advertised services to be re-registered, which may cause temporary unavailability of this node for purposes of service discovery.
 
 Delivering a signal to Containerbuddy is most easily done by using `docker exec` and relying on the fact that it is being used as PID1.
 

--- a/examples/nginx/opt/containerbuddy/nginx.json
+++ b/examples/nginx/opt/containerbuddy/nginx.json
@@ -5,7 +5,7 @@
       "name": "nginx",
       "port": 80,
       "interfaces": ["eth0"],
-      "health": "/usr/bin/curl --fail -s http://localhost/health.txt",
+      "health": "/usr/bin/curl --fail -s -o /dev/null http://localhost/health.txt",
       "poll": 10,
       "ttl": 25
     }

--- a/makefile
+++ b/makefile
@@ -88,10 +88,15 @@ release: build ship
 example: build
 	cp build/containerbuddy ${ROOT}/examples/nginx/opt/containerbuddy/containerbuddy
 	cp build/containerbuddy ${ROOT}/examples/app/opt/containerbuddy/containerbuddy
-	cd examples/app && docker build -t 0x74696d/containerbuddy-demo-app .
-	cd examples/nginx && docker build -t 0x74696d/containerbuddy-demo-nginx .
+	cd examples && docker-compose -p example -f docker-compose-local.yml build
 
-# build example and ship to Docker Hub registry
+# run example application locally for testing
+run: example
+	cd examples && ./start.sh -p example -f docker-compose-local.yml
+
+# tag and ship example to Docker Hub registry
 ship: example
+	docker tag example_nginx 0x74696d/containerbuddy-demo-nginx
+	docker tag example_app 0x74696d/containerbuddy-demo-app
 	docker push 0x74696d/containerbuddy-demo-nginx
 	docker push 0x74696d/containerbuddy-demo-app

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -138,9 +138,16 @@ func loadConfig() (*Config, error) {
 
 	var configFlag string
 	var versionFlag bool
-	flag.StringVar(&configFlag, "config", "", "JSON config or file:// path to JSON config file.")
-	flag.BoolVar(&versionFlag, "version", false, "Show version identifier and quit.")
-	flag.Parse()
+
+	if !flag.Parsed() {
+		flag.StringVar(&configFlag, "config", "",
+			"JSON config or file:// path to JSON config file.")
+		flag.BoolVar(&versionFlag, "version", false, "Show version identifier and quit.")
+		flag.Parse()
+	} else {
+		// allows for safe configuration reload
+		configFlag = flag.Lookup("config").Value.String()
+	}
 	if versionFlag {
 		fmt.Printf("Version: %s\nGitHash: %s\n", Version, GitHash)
 		os.Exit(0)

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -54,6 +54,9 @@ func TestValidConfigParse(t *testing.T) {
 	os.Setenv("TEST", "HELLO")
 	os.Args = []string{"this", "-config", testJson, "/test.sh", "valid1", "--debug"}
 	config, _ := loadConfig()
+	if !reflect.DeepEqual(config, getConfig()) {
+		t.Errorf("Global config was not written after load")
+	}
 
 	if len(config.Backends) != 2 || len(config.Services) != 2 {
 		t.Errorf("Expected 2 backends and 2 services but got: %v", config)

--- a/src/containerbuddy/main.go
+++ b/src/containerbuddy/main.go
@@ -21,19 +21,9 @@ func main() {
 		os.Exit(onStartCode)
 	}
 
-	// Set up signal handler for placing instance into maintenance mode
+	// Set up handlers for polling and to accept signal interrupts
 	handleSignals(config)
-
-	// Set up polling operations
 	handlePolling(config)
-
-	// gracefully clean up so that our docker logs aren't cluttered after an exit 0
-	// TODO: do we really need this?
-	defer func() {
-		for _, ch := range config.QuitChannels {
-			close(ch)
-		}
-	}()
 
 	if len(flag.Args()) != 0 {
 		// Run our main application and capture its stdout/stderr.
@@ -45,7 +35,7 @@ func main() {
 			log.Println(err)
 		}
 		// Run the PostStop handler, if any, and exit if it returns an error
-		if postStopCode, err := run(config.postStopCmd); err != nil {
+		if postStopCode, err := run(getConfig().postStopCmd); err != nil {
 			os.Exit(postStopCode)
 		}
 		os.Exit(code)


### PR DESCRIPTION
@misterbisson @justenwalker this PR supports reloading the configuration (ref https://github.com/joyent/containerbuddy/issues/9). This is not a completed implementation, but I figure getting in front of you guys would be a good idea. There will also almost certainly be merge conflicts with https://github.com/joyent/containerbuddy/pull/46 so I'll be sure to clean those up first.

We accept SIGHUP to reload the configuration. This stops all polling and forces all advertised services to be deregistered (and then reloaded) in the discovery service. We have to do this because otherwise we can't actually update service configurations in Consul.

~~Right now the fairly large hole in the implementation that I'm planning on taking on starting tomorrow morning is that we don't properly cover the `preStop` and `postStop` functions. We pass their config struct in `main`, which is outside the loop for getting the config. It's just a bit of refactoring so we can stick the config in at the appropriate moment.~~ *Done*