### PR TITLE
Reformat code to pass golint checks

### DIFF
--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -19,17 +19,17 @@ type MockAddr struct {
 	StringAttr  string
 }
 
-func (self MockAddr) Network() string {
-	return self.NetworkAttr
+func (addr MockAddr) Network() string {
+	return addr.NetworkAttr
 }
 
-func (self MockAddr) String() string {
-	return self.StringAttr
+func (addr MockAddr) String() string {
+	return addr.StringAttr
 }
 
 // ------------------------------------------
 
-var testJson = `{
+var testJSON = `{
 	"consul": "consul:8500",
 	"onStart": "/bin/to/onStart.sh arg1 arg2",
 	"preStop": ["/bin/to/preStop.sh","arg1","arg2"],
@@ -71,7 +71,7 @@ func TestValidConfigParse(t *testing.T) {
 	defer argTestCleanup(argTestSetup())
 
 	os.Setenv("TEST", "HELLO")
-	os.Args = []string{"this", "-config", testJson, "/test.sh", "valid1", "--debug"}
+	os.Args = []string{"this", "-config", testJSON, "/test.sh", "valid1", "--debug"}
 	config, _ := loadConfig()
 	if !reflect.DeepEqual(config, getConfig()) {
 		t.Errorf("Global config was not written after load")
@@ -173,7 +173,7 @@ func validateCommandParsed(t *testing.T, name string, parsed *exec.Cmd, expected
 func TestInvalidConfigNoConfigFlag(t *testing.T) {
 	defer argTestCleanup(argTestSetup())
 	os.Args = []string{"this", "/test.sh", "invalid1", "--debug"}
-	if _, err := loadConfig(); err != nil && err.Error() != "-config flag is required." {
+	if _, err := loadConfig(); err != nil && err.Error() != "-config flag is required" {
 		t.Errorf("Expected error but got %s", err)
 	}
 }
@@ -195,7 +195,7 @@ func TestInvalidConfigParseNotJson(t *testing.T) {
 		"Parse error at line:col [1:1]")
 }
 
-func TestJsonTemplateParseError(t *testing.T) {
+func testJSONTemplateParseError(t *testing.T) {
 	defer argTestCleanup(argTestSetup())
 	testParseExpectError(t,
 		`{
@@ -205,7 +205,7 @@ func TestJsonTemplateParseError(t *testing.T) {
 		"Parse error at line:col [2:13]")
 }
 
-func TestJsonTemplateParseError2(t *testing.T) {
+func testJSONTemplateParseError2(t *testing.T) {
 	defer argTestCleanup(argTestSetup())
 	testParseExpectError(t,
 		`{
@@ -218,22 +218,22 @@ func TestJsonTemplateParseError2(t *testing.T) {
 }
 
 func TestGetIp(t *testing.T) {
-	if ip, _ := getIp([]string{}); ip == "" {
+	if ip, _ := getIP([]string{}); ip == "" {
 		t.Errorf("Expected default interface to yield an IP, but got nothing.")
 	}
-	if ip, _ := getIp(nil); ip == "" {
+	if ip, _ := getIP(nil); ip == "" {
 		t.Errorf("Expected default interface to yield an IP, but got nothing.")
 	}
-	if ip, _ := getIp([]string{"eth0"}); ip == "" {
+	if ip, _ := getIP([]string{"eth0"}); ip == "" {
 		t.Errorf("Expected to find IP for eth0, but found nothing.")
 	}
-	if ip, _ := getIp([]string{"eth0", "lo"}); ip == "127.0.0.1" {
+	if ip, _ := getIP([]string{"eth0", "lo"}); ip == "127.0.0.1" {
 		t.Errorf("Expected to find eth0 ip, but found loopback instead")
 	}
-	if ip, _ := getIp([]string{"lo", "eth0"}); ip != "127.0.0.1" {
+	if ip, _ := getIP([]string{"lo", "eth0"}); ip != "127.0.0.1" {
 		t.Errorf("Expected to find loopback ip, but found: %s", ip)
 	}
-	if ip, err := getIp([]string{"interface-does-not-exist"}); err == nil {
+	if ip, err := getIP([]string{"interface-does-not-exist"}); err == nil {
 		t.Errorf("Expected interface not found, but instead got an IP: %s", ip)
 	}
 }
@@ -274,23 +274,23 @@ func TestConfigRequiredFields(t *testing.T) {
 	// --------------
 
 	// Missing `name`
-	testConfig = unmarshalTestJson()
+	testConfig = unmarshaltestJSON()
 	testConfig.Services[0].Name = ""
 	validateParseError(t, []string{"`name`"}, testConfig)
 	// Missing `poll`
-	testConfig = unmarshalTestJson()
+	testConfig = unmarshaltestJSON()
 	testConfig.Services[0].Poll = 0
 	validateParseError(t, []string{"`poll`", testConfig.Services[0].Name}, testConfig)
 	// Missing `ttl`
-	testConfig = unmarshalTestJson()
+	testConfig = unmarshaltestJSON()
 	testConfig.Services[0].TTL = 0
 	validateParseError(t, []string{"`ttl`", testConfig.Services[0].Name}, testConfig)
 	// Missing `health`
-	testConfig = unmarshalTestJson()
+	testConfig = unmarshaltestJSON()
 	testConfig.Services[0].HealthCheckExec = nil
 	validateParseError(t, []string{"`health`", testConfig.Services[0].Name}, testConfig)
 	// Missing `port`
-	testConfig = unmarshalTestJson()
+	testConfig = unmarshaltestJSON()
 	testConfig.Services[0].Port = 0
 	validateParseError(t, []string{"`port`", testConfig.Services[0].Name}, testConfig)
 
@@ -299,15 +299,15 @@ func TestConfigRequiredFields(t *testing.T) {
 	// --------------
 
 	// Missing `name`
-	testConfig = unmarshalTestJson()
+	testConfig = unmarshaltestJSON()
 	testConfig.Backends[0].Name = ""
 	validateParseError(t, []string{"`name`"}, testConfig)
 	// Missing `poll`
-	testConfig = unmarshalTestJson()
+	testConfig = unmarshaltestJSON()
 	testConfig.Backends[0].Poll = 0
 	validateParseError(t, []string{"`poll`", testConfig.Backends[0].Name}, testConfig)
 	// Missing `onChange`
-	testConfig = unmarshalTestJson()
+	testConfig = unmarshaltestJSON()
 	testConfig.Backends[0].OnChangeExec = nil
 	validateParseError(t, []string{"`onChange`", testConfig.Backends[0].Name}, testConfig)
 }
@@ -334,7 +334,7 @@ func TestInterfaceIpsLoopback(t *testing.T) {
 		Flags: net.FlagUp | net.FlagLoopback,
 	}
 
-	interfaceIps, err := getInterfaceIps(interfaces)
+	interfaceIps, err := getinterfaceIPs(interfaces)
 
 	if err != nil {
 		t.Error(err)
@@ -371,7 +371,7 @@ func TestInterfaceIpsError(t *testing.T) {
 		HardwareAddr: []byte{0x10, 0xC3, 0x7B, 0x45, 0xA2, 0xFF},
 	}
 
-	interfaceIps, err := getInterfaceIps(interfaces)
+	interfaceIps, err := getinterfaceIPs(interfaces)
 
 	if err != nil {
 		t.Error(err)
@@ -391,7 +391,7 @@ func TestInterfaceIpsError(t *testing.T) {
 }
 
 func TestParseIPv4FromSingleAddress(t *testing.T) {
-	expectedIp := "192.168.22.123"
+	expectedIP := "192.168.22.123"
 
 	intf := net.Interface{
 		Index:        -1,
@@ -403,24 +403,24 @@ func TestParseIPv4FromSingleAddress(t *testing.T) {
 
 	addr := MockAddr{
 		NetworkAttr: "ip+net",
-		StringAttr:  expectedIp + "/8",
+		StringAttr:  expectedIP + "/8",
 	}
 
-	ifaceIp, err := parseIpFromAddress(addr, intf)
+	ifaceIP, err := parseIPFromAddress(addr, intf)
 
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	if ifaceIp.IP != expectedIp {
+	if ifaceIP.IP != expectedIP {
 		t.Errorf("IP didn't match expectation. Actual: %s Expected: %s",
-			ifaceIp.IP, expectedIp)
+			ifaceIP.IP, expectedIP)
 	}
 }
 
 func TestParseIPv4FromIPv6AndIPv4AddressesIPv4First(t *testing.T) {
-	expectedIp := "192.168.22.123"
+	expectedIP := "192.168.22.123"
 
 	intf := net.Interface{
 		Index:        -1,
@@ -432,24 +432,24 @@ func TestParseIPv4FromIPv6AndIPv4AddressesIPv4First(t *testing.T) {
 
 	addr := MockAddr{
 		NetworkAttr: "ip+net",
-		StringAttr:  expectedIp + "/8" + " fe80::12c3:7bff:fe45:a2ff/64",
+		StringAttr:  expectedIP + "/8" + " fe80::12c3:7bff:fe45:a2ff/64",
 	}
 
-	ifaceIp, err := parseIpFromAddress(addr, intf)
+	ifaceIP, err := parseIPFromAddress(addr, intf)
 
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	if ifaceIp.IP != expectedIp {
+	if ifaceIP.IP != expectedIP {
 		t.Errorf("IP didn't match expectation. Actual: %s Expected: %s",
-			ifaceIp.IP, expectedIp)
+			ifaceIP.IP, expectedIP)
 	}
 }
 
 func TestParseIPv4FromIPv6AndIPv4AddressesIPv6First(t *testing.T) {
-	expectedIp := "192.168.22.123"
+	expectedIP := "192.168.22.123"
 
 	intf := net.Interface{
 		Index:        -1,
@@ -461,19 +461,19 @@ func TestParseIPv4FromIPv6AndIPv4AddressesIPv6First(t *testing.T) {
 
 	addr := MockAddr{
 		NetworkAttr: "ip+net",
-		StringAttr:  "fe80::12c3:7bff:fe45:a2ff/64 " + expectedIp + "/8",
+		StringAttr:  "fe80::12c3:7bff:fe45:a2ff/64 " + expectedIP + "/8",
 	}
 
-	ifaceIp, err := parseIpFromAddress(addr, intf)
+	ifaceIP, err := parseIPFromAddress(addr, intf)
 
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	if ifaceIp.IP != expectedIp {
+	if ifaceIP.IP != expectedIP {
 		t.Errorf("IP didn't match expectation. Actual: %s Expected: %s",
-			ifaceIp.IP, expectedIp)
+			ifaceIP.IP, expectedIP)
 	}
 }
 
@@ -490,14 +490,14 @@ func argTestCleanup(oldArgs []string) {
 	os.Args = oldArgs
 }
 
-func testParseExpectError(t *testing.T, testJson string, expected string) {
-	os.Args = []string{"this", "-config", testJson, "/test.sh", "test", "--debug"}
+func testParseExpectError(t *testing.T, testJSON string, expected string) {
+	os.Args = []string{"this", "-config", testJSON, "/test.sh", "test", "--debug"}
 	if _, err := loadConfig(); err != nil && !strings.Contains(err.Error(), expected) {
 		t.Errorf("Expected %s but got %s", expected, err)
 	}
 }
 
-func unmarshalTestJson() *Config {
-	config, _ := unmarshalConfig([]byte(testJson))
+func unmarshaltestJSON() *Config {
+	config, _ := unmarshalConfig([]byte(testJSON))
 	return config
 }

--- a/src/containerbuddy/discovery.go
+++ b/src/containerbuddy/discovery.go
@@ -1,5 +1,7 @@
 package main
 
+// DiscoveryService is an interface
+// which all service discovery backends must implement
 type DiscoveryService interface {
 	SendHeartbeat(*ServiceConfig)
 	CheckForUpstreamChanges(*BackendConfig) bool

--- a/src/containerbuddy/discovery_test.go
+++ b/src/containerbuddy/discovery_test.go
@@ -10,7 +10,7 @@ func setupConsul(serviceName string) *Config {
 	config := &Config{
 		Services: []*ServiceConfig{
 			&ServiceConfig{
-				Id:               serviceName,
+				ID:               serviceName,
 				Name:             serviceName,
 				ipAddress:        "192.168.1.1",
 				TTL:              1,
@@ -32,7 +32,7 @@ func TestTTLPass(t *testing.T) {
 	config := setupConsul("service-TestTTLPass")
 	service := config.Services[0]
 	consul := service.discoveryService.(Consul)
-	id := service.Id
+	id := service.ID
 
 	service.SendHeartbeat() // force registration
 	checks, _ := consul.Agent().Checks()
@@ -54,7 +54,7 @@ func TestCheckForChanges(t *testing.T) {
 	backend := config.Backends[0]
 	service := config.Services[0]
 	consul := backend.discoveryService.(Consul)
-	id := service.Id
+	id := service.ID
 	if consul.checkHealth(*backend) {
 		t.Fatalf("First read of %s should show `false` for change", id)
 	}

--- a/src/containerbuddy/signals.go
+++ b/src/containerbuddy/signals.go
@@ -68,8 +68,8 @@ func terminate(config *Config) {
 func reloadConfig(config *Config) *Config {
 	signalLock.Lock()
 	defer signalLock.Unlock()
-	newConfig, err := loadConfig()
 	log.Printf("Reloading configuration.\n")
+	newConfig, err := loadConfig()
 	if err != nil {
 		log.Printf("Could not reload config: %v\n", err)
 		return nil

--- a/src/containerbuddy/signals.go
+++ b/src/containerbuddy/signals.go
@@ -68,26 +68,25 @@ func terminate(config *Config) {
 func reloadConfig(config *Config) *Config {
 	signalLock.Lock()
 	defer signalLock.Unlock()
-
+	newConfig, err := loadConfig()
 	log.Printf("Reloading configuration.\n")
-	if newConfig, err := loadConfig(); err != nil {
+	if err != nil {
 		log.Printf("Could not reload config: %v\n", err)
 		return nil
-	} else {
-		// stop advertising the existing services so that we can
-		// make sure we update them if ports, etc. change.
-		stopPolling(config)
-		forAllServices(config, func(service *ServiceConfig) {
-			log.Printf("Deregistering service: %s\n", service.Name)
-			service.Deregister()
-		})
-
-		signal.Reset()
-		handleSignals(newConfig)
-		handlePolling(newConfig)
-
-		return newConfig // return for debuggability
 	}
+	// stop advertising the existing services so that we can
+	// make sure we update them if ports, etc. change.
+	stopPolling(config)
+	forAllServices(config, func(service *ServiceConfig) {
+		log.Printf("Deregistering service: %s\n", service.Name)
+		service.Deregister()
+	})
+
+	signal.Reset()
+	handleSignals(newConfig)
+	handlePolling(newConfig)
+
+	return newConfig // return for debuggability
 }
 
 func stopPolling(config *Config) {

--- a/src/containerbuddy/template.go
+++ b/src/containerbuddy/template.go
@@ -8,6 +8,7 @@ import (
 	"text/template"
 )
 
+// Environment is a map of environment variables to their values
 type Environment map[string]string
 
 func parseEnvironment(environ []string) Environment {
@@ -22,6 +23,8 @@ func parseEnvironment(environ []string) Environment {
 	return env
 }
 
+// ConfigTemplate encapsulates a golang template
+// and its associated environment variables.
 type ConfigTemplate struct {
 	Template *template.Template
 	Env      Environment
@@ -33,14 +36,15 @@ func defaultValue(defaultValue, templateValue interface{}) string {
 			return str
 		}
 	}
-	if defaultStr, ok := defaultValue.(string); !ok {
+	defaultStr, ok := defaultValue.(string)
+	if !ok {
 		return fmt.Sprintf("%v", defaultValue)
-	} else {
-		return defaultStr
 	}
+	return defaultStr
 }
 
-// Interpolate variables
+// NewConfigTemplate creates a ConfigTemplate parsed from the configuration
+// and the current environment variables
 func NewConfigTemplate(config []byte) (*ConfigTemplate, error) {
 	env := parseEnvironment(os.Environ())
 	tmpl, err := template.New("").Funcs(template.FuncMap{
@@ -55,6 +59,7 @@ func NewConfigTemplate(config []byte) (*ConfigTemplate, error) {
 	}, nil
 }
 
+// Execute renders the template
 func (c *ConfigTemplate) Execute() ([]byte, error) {
 	var buffer bytes.Buffer
 	if err := c.Template.Execute(&buffer, c.Env); err != nil {
@@ -63,6 +68,7 @@ func (c *ConfigTemplate) Execute() ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
+// ApplyTemplate creates and renders a template from the given config template
 func ApplyTemplate(config []byte) ([]byte, error) {
 	template, err := NewConfigTemplate(config)
 	if err != nil {


### PR DESCRIPTION
This PR fixes any warnings that [golint](https://github.com/golang/lint) prints when run on the containerbuddy sources.  

**This does have a good chance of causing merge errors with in-progress branches.**

## Changes

- Fix identifier name casing
- Add doc comments to exported objects
- Refactor some code to satisfy golint style suggestions (else blocks, post-increment)

## How to lint the containerbuddy sources

```
$ go get -u github.com/golang/lint/golint
$ $GOPATH/bin/golint -min_confidence 0.8 src/containerbuddy
```

*Note:* **golint** is not a panacea for style errors, but it's a good place to start catching them.  It makes it easier to be idiomatic & consistent with the styles described in [Effective Go](https://golang.org/doc/effective_go.html). If it is not too onerous, it could also help remind us to include documentation (although I do find it easy to write terse 1-liners just to make the warning go away)