### PR TITLE
Enable docker-compose to scale app.

### DIFF
--- a/examples/docker-compose-local.yml
+++ b/examples/docker-compose-local.yml
@@ -43,7 +43,7 @@ app:
     links:
     - consul:consul
     ports:
-    - 8000:8000
+    - 8000
     restart: always
     command: >
       /opt/containerbuddy/containerbuddy


### PR DESCRIPTION
The previous docker-compose-local.yml specified the host port for the app service.  As a result, running `docker-compose scale app=3` would fail because the second and third containers would attempt to bind to the same port on the docker host.  By removing the host portion of the port configuration, docker-compose chooses random port numbers for the host when scaling the app.
https://docs.docker.com/compose/compose-file/#ports