### PR TITLE
Factor the go make stuff into a docker makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,9 @@ _testmain.go
 *.prof
 
 # more build and test outputs
-coverage.out
-.godeps/
 build/
 release/
+cover/
 examples/*/opt/containerbuddy/containerbuddy
 *.tar.gz
+build-image

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
 ---
 sudo: required
 
-language: go
-go:
-  - 1.5.1
-
 services:
   - docker
 
 script:
-  - make
-  - make test
+  - make clean lint build test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang
+
+RUN go get -u github.com/golang/lint/golint
+
+ENV CGO_ENABLED 0
+ENTRYPOINT ["make"]

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,0 +1,35 @@
+#! /usr/bin/env make -f
+
+MAKEFLAGS += --warn-undefined-variables
+SHELL := /bin/bash
+.SHELLFLAGS = -o pipefail -euc
+.DEFAULT_GOAL := build
+
+.PHONY: all build deps check test cover
+
+CONSUL_REF := 158eabdd6f2408067c1d7656fa10e49434f96480
+
+ROOT := /go
+CDWD := cd ${ROOT}/src/containerbuddy
+
+all: build cover
+
+build: deps
+	${CDWD} && go build -a -o /build/containerbuddy -ldflags "$(LDFLAGS)"
+	chmod 755 /build/containerbuddy
+
+deps:
+	mkdir -p "${ROOT}/src/github.com/hashicorp"
+	git clone https://github.com/hashicorp/consul.git ${ROOT}/src/github.com/hashicorp/consul
+	cd ${ROOT}/src/github.com/hashicorp/consul && git checkout ${CONSUL_REF}
+
+lint:
+	${CDWD} && go vet
+	${CDWD} && go fmt
+	golint ${ROOT}/src/containerbuddy
+
+test: deps
+	${CDWD} && go test -v -coverprofile=/cover/coverage.out
+
+cover: test
+	go tool cover -html=/cover/coverage.out -o /cover/coverage.html

--- a/makefile
+++ b/makefile
@@ -50,7 +50,7 @@ test: docker cover/coverage.out
 cover/coverage.out:
 	${DOCKERMAKE} test
 
-cover: cover/coverage.html
+cover: docker cover/coverage.html
 
 cover/coverage.html:
 	${DOCKERMAKE} cover

--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ clean:
 
 build/containerbuddy_build:
 	mkdir -p ${ROOT}/build
-	docker rmi -f containerbuddy_build || true
+	docker rmi -f containerbuddy_build > /dev/null 2>&1 || true
 	docker build -t containerbuddy_build ${ROOT}
 	docker inspect -f "{{ .ID }}" containerbuddy_build > build/containerbuddy_build
 


### PR DESCRIPTION
I had this idea to factor out the build logic into a docker-specific makefile.  IMO it makes the build tasks easier to maintain. Does this seem like a good idea?

## Changes

- Factor build / test logic into Makefile.docker
- Create Dockerfile for creating the build environment
- Make coverage generate html file instead of opening a browser

The main `makefile`:

1. Create a build environment: `containerbuddy_build`
2. Set up middleware for integration tests: `containerbuddy_consul`
3. All the release logic for post-build

The new `Makefile.docker` contains all of the targets for building, testing, format/linting, coverage, etc...
It is able to assume it runs in a consistent and initialized build environment - so there doesn't need to be any setup logic inside of it.

### Modified makefile targets

- `make clean` - Cleans up build artifacts and removes build environment docker images
- `make build` - **Default target**, builds containerbuddy
- `make test` - Runs unit tests
- `make cover` - Generates coverage report HTML
- `make lint` - Runs go vet, go fmt, and golint
