### PR TITLE
Add support for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ The format of the JSON file configuration is as follows:
         "eth0"
       ],
       "poll": 10,
-      "ttl": 30
+      "ttl": 30,
+      "tags": ["tag1"]
     }
   ],
   "backends": [
@@ -88,6 +89,7 @@ Service fields:
 - `interfaces` is an optional single interface name or array of interfaces in priority order. If given, the IP of the service will be obtained from the first interface that exits in the container. (Default value is `["eth0"]`)
 - `poll` is the time in seconds between polling for health checks.
 - `ttl` is the time-to-live of a successful health check. This should be longer than the polling rate so that the polling process and the TTL aren't racing; otherwise Consul will mark the service as unhealthy.
+- `tags` is an optional array of tags. If the discovery service supports it (Consul does), the service will register itself with these tags.
 
 Backend fields:
 

--- a/examples/app/opt/containerbuddy/app.json
+++ b/examples/app/opt/containerbuddy/app.json
@@ -20,7 +20,8 @@
     {
       "name": "app",
       "poll": 5,
-      "onChange": "/opt/containerbuddy/reload-app.sh"
+      "onChange": "/opt/containerbuddy/reload-app.sh",
+      "tag": "application"
     }
   ]
 }

--- a/examples/app/opt/containerbuddy/app.json
+++ b/examples/app/opt/containerbuddy/app.json
@@ -7,7 +7,8 @@
       "port": 8000,
       "health": "/usr/bin/curl --fail -s http://localhost:8000",
       "poll": 10,
-      "ttl": 25
+      "ttl": 25,
+      "tags": ["application"]
     }
   ],
   "backends": [

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -76,6 +76,7 @@ type BackendConfig struct {
 	Name             string          `json:"name"`
 	Poll             int             `json:"poll"` // time in seconds
 	OnChangeExec     json.RawMessage `json:"onChange"`
+	Tag              string          `json:"tag,omitempty"`
 	discoveryService DiscoveryService
 	lastState        interface{}
 	onChangeCmd      *exec.Cmd

--- a/src/containerbuddy/config.go
+++ b/src/containerbuddy/config.go
@@ -65,6 +65,7 @@ type ServiceConfig struct {
 	Port             int             `json:"port"`
 	TTL              int             `json:"ttl"`
 	Interfaces       json.RawMessage `json:"interfaces"`
+	Tags             []string        `json:"tags,omitempty"`
 	discoveryService DiscoveryService
 	ipAddress        string
 	healthCheckCmd   *exec.Cmd

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -92,8 +92,16 @@ func TestValidConfigParse(t *testing.T) {
 		t.Errorf("Expected tags %s for serviceA, but got: %s", expectedTags, config.Services[0].Tags)
 	}
 
+	if config.Services[1].Tags != nil {
+		t.Errorf("Expected no tags for serviceB, but got: %s", config.Services[1].Tags)
+	}
+
 	if config.Backends[0].Tag != "dev" {
 		t.Errorf("Expected tag %s for upstreamA, but got: %s", "dev", config.Backends[0].Tag)
+	}
+
+	if config.Backends[1].Tag != "" {
+		t.Errorf("Expected no tag for upstreamB, but got: %s", config.Backends[1].Tag)
 	}
 
 	validateCommandParsed(t, "onStart", config.onStartCmd, []string{"/bin/to/onStart.sh", "arg1", "arg2"})

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -41,7 +41,8 @@ var testJSON = `{
 					"interfaces": "eth0",
 					"health": "/bin/to/healthcheck/for/service/A.sh",
 					"poll": 30,
-					"ttl": 19
+					"ttl": 19,
+					"tags": ["tag1","tag2"]
 			},
 			{
 					"name": "serviceB",
@@ -83,6 +84,11 @@ func TestValidConfigParse(t *testing.T) {
 	args := flag.Args()
 	if len(args) != 3 || args[0] != "/test.sh" {
 		t.Errorf("Expected 3 args but got unexpected results: %v", args)
+	}
+
+	expectedTags := []string{"tag1", "tag2"}
+	if !reflect.DeepEqual(config.Services[0].Tags, expectedTags) {
+		t.Errorf("Expected tags %s for serviceA, but got: %s", expectedTags, config.Services[0].Tags)
 	}
 
 	validateCommandParsed(t, "onStart", config.onStartCmd, []string{"/bin/to/onStart.sh", "arg1", "arg2"})

--- a/src/containerbuddy/config_test.go
+++ b/src/containerbuddy/config_test.go
@@ -57,7 +57,8 @@ var testJSON = `{
 			{
 					"name": "upstreamA",
 					"poll": 11,
-					"onChange": "/bin/to/onChangeEvent/for/upstream/A.sh {{.TEST}}"
+					"onChange": "/bin/to/onChangeEvent/for/upstream/A.sh {{.TEST}}",
+					"tag": "dev"
 			},
 			{
 					"name": "upstreamB",
@@ -89,6 +90,10 @@ func TestValidConfigParse(t *testing.T) {
 	expectedTags := []string{"tag1", "tag2"}
 	if !reflect.DeepEqual(config.Services[0].Tags, expectedTags) {
 		t.Errorf("Expected tags %s for serviceA, but got: %s", expectedTags, config.Services[0].Tags)
+	}
+
+	if config.Backends[0].Tag != "dev" {
+		t.Errorf("Expected tag %s for upstreamA, but got: %s", "dev", config.Backends[0].Tag)
 	}
 
 	validateCommandParsed(t, "onStart", config.onStartCmd, []string{"/bin/to/onStart.sh", "arg1", "arg2"})

--- a/src/containerbuddy/consul.go
+++ b/src/containerbuddy/consul.go
@@ -82,7 +82,7 @@ func (c Consul) CheckForUpstreamChanges(backend *BackendConfig) bool {
 }
 
 func (c *Consul) checkHealth(backend BackendConfig) bool {
-	services, meta, err := c.Health().Service(backend.Name, "", true, nil)
+	services, meta, err := c.Health().Service(backend.Name, backend.Tag, true, nil)
 	if err != nil {
 		log.Printf("Failed to query %v: %s [%v]", backend.Name, err, meta)
 		return false

--- a/src/containerbuddy/consul.go
+++ b/src/containerbuddy/consul.go
@@ -53,6 +53,7 @@ func (c *Consul) registerService(service ServiceConfig) error {
 		&consul.AgentServiceRegistration{
 			ID:      service.ID,
 			Name:    service.Name,
+			Tags:    service.Tags,
 			Port:    service.Port,
 			Address: service.ipAddress,
 		},


### PR DESCRIPTION
For #10 

Add support for `tags` in the service configuration. Didn't seem like too much work to add, so I'm afraid I may have glossed over some important details. 

Another set of eyes appreciated.