### PR TITLE
Make golang dependencies a non-phony target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ release/
 cover/
 examples/*/opt/containerbuddy/containerbuddy
 *.tar.gz
-build-image
+.godeps

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 .SHELLFLAGS = -o pipefail -euc
 .DEFAULT_GOAL := build
 
-.PHONY: all build deps check test cover
+.PHONY: all build check test cover
 
 CONSUL_REF := 158eabdd6f2408067c1d7656fa10e49434f96480
 
@@ -14,11 +14,11 @@ CDWD := cd ${ROOT}/src/containerbuddy
 
 all: build cover
 
-build: deps
+build: /go/src/github.com
 	${CDWD} && go build -a -o /build/containerbuddy -ldflags "$(LDFLAGS)"
 	chmod 755 /build/containerbuddy
 
-deps:
+/go/src/github.com:
 	mkdir -p "${ROOT}/src/github.com/hashicorp"
 	git clone https://github.com/hashicorp/consul.git ${ROOT}/src/github.com/hashicorp/consul
 	cd ${ROOT}/src/github.com/hashicorp/consul && git checkout ${CONSUL_REF}
@@ -28,7 +28,7 @@ lint:
 	${CDWD} && go fmt
 	golint ${ROOT}/src/containerbuddy
 
-test: deps
+test: /go/src/github.com
 	${CDWD} && go test -v -coverprofile=/cover/coverage.out
 
 cover: test

--- a/makefile
+++ b/makefile
@@ -12,6 +12,7 @@ ROOT := $(shell pwd)
 
 DOCKERMAKE := docker run --rm --link containerbuddy_consul:consul \
 	-v ${ROOT}/src/containerbuddy:/go/src/containerbuddy \
+	-v ${ROOT}/.godeps:/go/src \
 	-v ${ROOT}/build:/build \
 	-v ${ROOT}/cover:/cover \
 	-v ${ROOT}/examples:/root/examples:ro \
@@ -20,7 +21,7 @@ DOCKERMAKE := docker run --rm --link containerbuddy_consul:consul \
 	containerbuddy_build
 
 clean:
-	rm -rf build release cover
+	rm -rf build release cover .godeps
 	docker rmi -f containerbuddy_build > /dev/null 2>&1 || true
 	docker rm -f containerbuddy_consul > /dev/null 2>&1 || true
 


### PR DESCRIPTION
For https://github.com/joyent/containerbuddy/issues/64

Mount the `.godeps/` directory (on the local machine) to a spot nested within the `/go/src` directory in the build container so that we can run our build without manipulating the `GOPATH` but still take advantage of caching the cloned dependencies on disk.

cc @justenwalker 