### PR TITLE
Pin GOMAXPROCS=1

### DIFF
--- a/src/containerbuddy/main.go
+++ b/src/containerbuddy/main.go
@@ -5,11 +5,15 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"syscall"
 	"time"
 )
 
 func main() {
+	// make sure we use only a single CPU so as not to cause
+	// contention on the main application
+	runtime.GOMAXPROCS(1)
 
 	config, configErr := loadConfig()
 	if configErr != nil {


### PR DESCRIPTION
The `GOMAXPROCS` runtime variable is set by default (in Go 1.5+) to be equal to the number of visible CPUs. The runtime uses M:N threading and so we can expect multiple threads. Containerbuddy has minimal performance requirements, so potentially creating a thread for each core will increase thread-switching for the main application that we care about. This might particularly be an issue in environments like Triton where `runtime.NumCPU` will see all the cores on the underlying CN and not the number that are likely to be available for scheduling.

References:

https://golang.org/pkg/runtime/#GOMAXPROCS
https://docs.google.com/document/d/1At2Ls5_fhJQ59kDK2DFVhFu3g5mATSXqqV5QrxinasI/edit

cc @misterbisson @justenwalker 