### PR TITLE
Add signal handler for SIGCHLD so we reap children

### DIFF
--- a/integration_tests/fixtures/zombie_maker/Dockerfile
+++ b/integration_tests/fixtures/zombie_maker/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.3
+
+ADD build/containerbuddy /bin/containerbuddy
+ADD app.json /app.json
+
+ADD zombie.sh /zombie.sh
+RUN chmod 755 /zombie.sh
+
+ENTRYPOINT [\
+  "/bin/containerbuddy","-config=file:///app.json",\
+  "tail","-f"]

--- a/integration_tests/fixtures/zombie_maker/app.json
+++ b/integration_tests/fixtures/zombie_maker/app.json
@@ -1,0 +1,13 @@
+{
+  "consul": "consul:8500",
+  "services": [
+    {
+      "name": "app",
+      "port": 8000,
+      "health": "/bin/sh /zombie.sh",
+      "poll": 1,
+      "ttl": 5,
+      "tags": ["application"]
+    }
+  ]
+}

--- a/integration_tests/fixtures/zombie_maker/zombie.sh
+++ b/integration_tests/fixtures/zombie_maker/zombie.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sleep 1 & exec /bin/sleep 2

--- a/integration_tests/tests/test_reap_zombies/docker-compose.yml
+++ b/integration_tests/tests/test_reap_zombies/docker-compose.yml
@@ -1,0 +1,12 @@
+consul:
+    image: "cbfix_consul"
+    mem_limit: 256m
+    hostname: consul
+
+app:
+    image: "cbfix_zombie_maker"
+    mem_limit: 512m
+    links:
+      - consul:consul
+    volumes:
+      - '${CONTAINERBUDDY_BIN}:/bin/containerbuddy:ro'

--- a/integration_tests/tests/test_reap_zombies/run.sh
+++ b/integration_tests/tests/test_reap_zombies/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+docker-compose up -d consul app > /dev/null 2>&1
+APP_ID="$(docker-compose ps -q app)"
+sleep 6
+NUM_ZOMBIES=$(docker exec $APP_ID ps -o stat,ppid,pid,comm | awk '
+BEGIN { count=0 }
+$1 ~ /^Z/ && $2 ~ /1/ { count++ }
+END { print count }
+')
+if [ $NUM_ZOMBIES -gt 1 ]; then
+  echo "Number of zombies > 1: $NUM_ZOMBIES" >&2
+  docker exec $APP_ID ps -o stat,ppid,pid,args
+  docker logs $APP_ID
+  exit 1
+fi
+exit 0

--- a/integration_tests/tests/test_sighup_deadlock/run.sh
+++ b/integration_tests/tests/test_sighup_deadlock/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker-compose up -d consul app > /dev/null 2>&1
+docker-compose up -d consul app
 APP_ID="$(docker-compose ps -q app)"
 docker-compose run --no-deps test /go/bin/test_probe test_sighup_deadlock $APP_ID > /dev/null 2>&1
 result=$?

--- a/src/containerbuddy/main.go
+++ b/src/containerbuddy/main.go
@@ -22,6 +22,9 @@ func main() {
 	}
 
 	// Set up handlers for polling and to accept signal interrupts
+	if 1 == os.Getpid() {
+		reapChildren()
+	}
 	handleSignals(config)
 	handlePolling(config)
 

--- a/src/containerbuddy/main.go
+++ b/src/containerbuddy/main.go
@@ -116,8 +116,12 @@ func executeAndWait(cmd *exec.Cmd) (int, error) {
 				return status.ExitStatus(), err
 			}
 		}
-		// only happens if we misconfigure, so just die here
-		log.Fatal(err)
+		// Should only happen if we misconfigure or there's some more
+		// serious problem with the underlying open/exec syscalls. But
+		// we'll let the lack of heartbeat tell us if something has gone
+		// wrong to that extent.
+		log.Println(err)
+		return 1, err
 	}
 	return 0, nil
 }

--- a/src/containerbuddy/signals_test.go
+++ b/src/containerbuddy/signals_test.go
@@ -61,7 +61,9 @@ func TestMaintenanceSignal(t *testing.T) {
 	}
 }
 
-// Test handler for SIGTERM
+// Test handler for SIGTERM. Note that the SIGCHLD handler is fired
+// by this same test, but that we don't have a separate unit test
+// because they'll interfere with each other's state.
 func TestTerminateSignal(t *testing.T) {
 
 	config := getSignalTestConfig()
@@ -105,6 +107,7 @@ func TestSignalWiring(t *testing.T) {
 	handleSignals(&Config{})
 	sendAndWaitForSignal(t, syscall.SIGUSR1)
 	sendAndWaitForSignal(t, syscall.SIGTERM)
+	sendAndWaitForSignal(t, syscall.SIGCHLD)
 	sendAndWaitForSignal(t, syscall.SIGHUP)
 }
 


### PR DESCRIPTION
For https://github.com/joyent/containerbuddy/issues/62

Also fires the handler for SIGCHLD when we fire our SIGTERM handler so that any children of the terminated process get reaped.

cc @misterbisson @justenwalker 