### PR TITLE
Integration Test Framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ cover/
 examples/**/opt/containerbuddy/containerbuddy
 *.tar.gz
 .godeps
+*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,24 @@
 ---
+language: go
+go:
+  - tip
+
 sudo: required
 
 services:
   - docker
 
+## Need docker-compose 1.5.x for Variable Interpolation
+env:
+  DOCKER_COMPOSE_VERSION: 1.5.2
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
 script:
-  - make clean lint build test
+  - make clean lint build
+  - make test
+  - make integration

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -1,0 +1,65 @@
+# Integration Tests
+
+## Running Tests
+
+- To run integration tests:
+
+`make integration` or `./test.sh test`
+
+- To run a single integration test:
+
+`./test.sh test test_name`
+
+- To clean fixtures. Next time tests are run they will be rebuilt.
+
+`make clean` or `./test.sh clean`
+
+## Making Tests
+
+### 1. Fixtures
+
+Fixtures Directory: `integration_tests/fixtures`
+
+- Folders in the fixtures directory will be built as docker images in alphabetical order
+- Each folder should contain a `Dockerfile` and any resources necessary to build the image
+- The resulting image will be named `cbfix_fixture_name`
+
+*Note*: Since fixtures are created in alpha order, they can have FROM directives for previously created images
+
+### 2. Tests
+
+Tests Directory: `integration_tests/tests`
+
+- Folders in the tests directory will be run as tests
+- Each folder must contain `run.sh`
+- The test folder can also contain `docker-compose.yml` for setting up the test environment and other resources it might need
+- If `run.sh` returns success: `0` then the test passed, otherwise it failed
+
+This script can make some assumptions:
+
+- It's current directory PWD is the same as the script.
+- Following environment variables are set:
+  - `COMPOSE_FILE`
+  - `COMPOSE_PROJECT_NAME` - The name of the test folder
+  - `DOCKER_IP` - The IP of docker on the host machine
+  - `CONTAINERBUDDY_BIN` - Absolute path to containerbuddy binary on the host.
+- all fixtures in `integration_tests/fixtures` are created and are available as images
+
+## How tests are executed
+
+### Setup Test Fixtures
+- Scan through all folders in `integration_tests/fixtures` in alpha order
+- For each fixture:
+  - Copy `build` into `integration_test/fixtures/fixture_name/build` so it can easily be sourced by the `Dockerfile`
+  - `cd integration_tests/fixtures/fixture_name`
+  - `docker build -t cbfix_fixture_name .`
+
+### Run tests
+- Scan through all folders in `integration_tests/tests` in alpha order
+- For each test:
+  - `cd integration_test/tests/test_name`
+  - Run `docker-compose build`
+  - Run `run.sh`
+  - Stop/kill the compose environment
+
+If *any* test fails, the test script will return a non-zero exit code.

--- a/integration_tests/fixtures/app_consul/Dockerfile
+++ b/integration_tests/fixtures/app_consul/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:slim
+
+RUN apt-get update && \
+    apt-get install -y \
+    curl \
+    unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g json http-server
+
+ADD build/containerbuddy /bin/containerbuddy
+ADD app.json /app.json
+
+ADD reload-app.sh /reload-app.sh
+RUN chmod 755 /reload-app.sh
+
+ENTRYPOINT [\
+  "/bin/containerbuddy","-config=file:///app.json",\
+  "/usr/local/bin/node","/usr/local/bin/http-server","/srv","-p","8000"]

--- a/integration_tests/fixtures/app_consul/app.json
+++ b/integration_tests/fixtures/app_consul/app.json
@@ -1,0 +1,27 @@
+{
+  "consul": "consul:8500",
+  "onStart": "/reload-app.sh",
+  "services": [
+    {
+      "name": "app",
+      "port": 8000,
+      "health": "/usr/bin/curl --fail -s http://localhost:8000",
+      "poll": 1,
+      "ttl": 5,
+      "tags": ["application"]
+    }
+  ],
+  "backends": [
+    {
+      "name": "nginx",
+      "poll": 7,
+      "onChange": "/reload-app.sh"
+    },
+    {
+      "name": "app",
+      "poll": 5,
+      "onChange": "/reload-app.sh",
+      "tag": "application"
+    }
+  ]
+}

--- a/integration_tests/fixtures/app_consul/reload-app.sh
+++ b/integration_tests/fixtures/app_consul/reload-app.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# get all the health application servers and write the json to file
+curl -s consul:8500/v1/health/service/app?passing | json > /tmp/lastQuery.json
+
+cat <<EOF > /srv/index.html
+<html>
+<head>
+<title>Containerbuddy Demo</title>
+<script>
+function timedRefresh(timeoutPeriod) {
+    setTimeout("location.reload(true);",timeoutPeriod);
+}
+</script>
+</head>
+<body onload="JavaScript:timedRefresh(5000);">
+<h1>Containerbuddy Demo</h1>
+<h2>This page served by app server: $(hostname)</h2>
+Last service health check changed at $(date):
+<pre>
+$(cat /tmp/lastQuery.json)
+</pre>
+<script>
+</body><html>
+EOF

--- a/integration_tests/fixtures/consul/Dockerfile
+++ b/integration_tests/fixtures/consul/Dockerfile
@@ -1,0 +1,3 @@
+FROM progrium/consul:latest
+
+EXPOSE 53 8300 8301 8302 8400 8500 8600

--- a/integration_tests/fixtures/consul/config/server.json
+++ b/integration_tests/fixtures/consul/config/server.json
@@ -1,0 +1,8 @@
+{
+	"ui_dir": "/ui",
+	"server": true,
+	"dns_config": {
+		"allow_stale": false
+	},
+  "bootstrap": true
+}

--- a/integration_tests/fixtures/etcd/Dockerfile
+++ b/integration_tests/fixtures/etcd/Dockerfile
@@ -1,0 +1,13 @@
+FROM quay.io/coreos/etcd:v2.0.8
+
+EXPOSE 2379 2380 4001
+
+CMD [\
+    "-name","etcd0",\
+    "-advertise-client-urls","http://etcd:2379,http://etcd:4001",\
+    "-listen-client-urls","http://0.0.0.0:2379,http://0.0.0.0:4001",\
+    "-initial-advertise-peer-urls","http://etcd:2380",\
+    "-listen-peer-urls","http://0.0.0.0:2380",\
+    "-initial-cluster-token","etcd-cluster-1",\
+    "-initial-cluster","etcd0=http://etcd:2380",\
+    "-initial-cluster-state","new"]

--- a/integration_tests/fixtures/node_consul/Dockerfile
+++ b/integration_tests/fixtures/node_consul/Dockerfile
@@ -1,0 +1,20 @@
+FROM nginx:latest
+
+RUN apt-get update && \
+    apt-get install -y \
+    curl \
+    unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -Lo /tmp/consul_template_0.11.0_linux_amd64.zip https://github.com/hashicorp/consul-template/releases/download/v0.11.0/consul_template_0.11.0_linux_amd64.zip && \
+    unzip /tmp/consul_template_0.11.0_linux_amd64.zip && \
+    mv consul-template /bin
+
+ADD build/containerbuddy /bin/containerbuddy
+ADD nginx.json /nginx.json
+
+ADD reload-nginx.sh /reload-nginx.sh
+
+ADD etc/nginx/conf.d /etc/nginx/conf.d/
+
+ENTRYPOINT ["/bin/containerbuddy","-config=file:///nginx.json","nginx","-g","daemon off;"]

--- a/integration_tests/fixtures/node_consul/default.ctmpl
+++ b/integration_tests/fixtures/node_consul/default.ctmpl
@@ -1,0 +1,32 @@
+# for each service, create a backend
+{{range services}}
+upstream {{.Name}} {
+    # write the health service address:port pairs for this backend
+    {{range service .Name}}
+    server {{.Address}}:{{.Port}};
+    {{end}}
+}
+{{end}}
+
+server {
+    listen       80;
+    server_name  _;
+
+    # if you have http_stub_status_module compiled-in, then
+    # this would be a good place to use /nginx_status
+    location /health.txt {
+        add_header content-type "text/html";
+        alias /usr/share/nginx/html/index.html;
+    }
+
+    {{range services}}
+    location = /{{.Name}} {
+        return 302 /{{.Name}}/;
+    }
+
+    location /{{.Name}} {
+        proxy_pass http://{{.Name}}/;
+        proxy_redirect off;
+    }
+    {{end}}
+}

--- a/integration_tests/fixtures/node_consul/etc/nginx/conf.d/default.conf
+++ b/integration_tests/fixtures/node_consul/etc/nginx/conf.d/default.conf
@@ -1,0 +1,13 @@
+# this is a localhost-only virtualhost configuration that lets us start Nginx
+# so we can get its real virtualhost config from consul-template
+server {
+    listen       80;
+    server_name  localhost 127.0.0.1;
+
+    # if you have http_stub_status_module compiled-in, then
+    # this would be a good place to use /nginx_status
+    location /health.txt {
+        add_header content-type "text/html";
+        alias /usr/share/nginx/html/index.html;
+    }
+}

--- a/integration_tests/fixtures/node_consul/nginx.json
+++ b/integration_tests/fixtures/node_consul/nginx.json
@@ -1,0 +1,20 @@
+{
+  "consul": "consul:8500",
+  "services": [
+    {
+      "name": "nginx",
+      "port": 80,
+      "interfaces": ["eth0"],
+      "health": "/usr/bin/curl --fail -s -o /dev/null http://localhost/health.txt",
+      "poll": 10,
+      "ttl": 25
+    }
+  ],
+  "backends": [
+    {
+      "name": "app",
+      "poll": 7,
+      "onChange": "/reload-nginx.sh"
+    }
+  ]
+}

--- a/integration_tests/fixtures/node_consul/opt/containerbuddy/nginx.json
+++ b/integration_tests/fixtures/node_consul/opt/containerbuddy/nginx.json
@@ -1,0 +1,20 @@
+{
+  "consul": "consul:8500",
+  "services": [
+    {
+      "name": "nginx",
+      "port": 80,
+      "interfaces": ["eth0"],
+      "health": "/usr/bin/curl --fail -s -o /dev/null http://localhost/health.txt",
+      "poll": 10,
+      "ttl": 25
+    }
+  ],
+  "backends": [
+    {
+      "name": "app",
+      "poll": 7,
+      "onChange": "/opt/containerbuddy/reload-nginx.sh"
+    }
+  ]
+}

--- a/integration_tests/fixtures/node_consul/opt/containerbuddy/reload-nginx.sh
+++ b/integration_tests/fixtures/node_consul/opt/containerbuddy/reload-nginx.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ -z "$VIRTUALHOST" ]; then
+    # fetch latest virtualhost template from Consul k/v
+    curl -s --fail consul:8500/v1/kv/nginx/template?raw > /tmp/virtualhost.ctmpl
+else
+    # dump the $VIRTUALHOST environment variable as a file
+    echo $VIRTUALHOST > /tmp/virtualhost.ctmpl
+fi
+
+# render virtualhost template using values from Consul and reload Nginx
+consul-template \
+    -once \
+    -consul consul:8500 \
+    -template "/tmp/virtualhost.ctmpl:/etc/nginx/conf.d/default.conf:nginx -s reload"

--- a/integration_tests/fixtures/node_consul/reload-nginx.sh
+++ b/integration_tests/fixtures/node_consul/reload-nginx.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ -z "$VIRTUALHOST" ]; then
+    # fetch latest virtualhost template from Consul k/v
+    curl -s --fail consul:8500/v1/kv/nginx/template?raw > /tmp/virtualhost.ctmpl
+else
+    # dump the $VIRTUALHOST environment variable as a file
+    echo $VIRTUALHOST > /tmp/virtualhost.ctmpl
+fi
+
+# render virtualhost template using values from Consul and reload Nginx
+consul-template \
+    -once \
+    -consul consul:8500 \
+    -template "/tmp/virtualhost.ctmpl:/etc/nginx/conf.d/default.conf:nginx -s reload"

--- a/integration_tests/fixtures/test_probe/Dockerfile
+++ b/integration_tests/fixtures/test_probe/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:latest
+
+ADD src /go/src/test_probe
+RUN go get github.com/hashicorp/consul
+RUN go get github.com/samalba/dockerclient
+
+RUN go install test_probe

--- a/integration_tests/fixtures/test_probe/src/consul.go
+++ b/integration_tests/fixtures/test_probe/src/consul.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	consul "github.com/hashicorp/consul/api"
+)
+
+const consulAddress = "consul:8500"
+
+// ConsulProbe is a test probe for consul
+type ConsulProbe interface {
+	WaitForServices(service string, tag string, count int) error
+}
+
+type consulClient struct {
+	Client *consul.Client
+}
+
+// NewConsulProbe creates a new ConsulProbe for testing consul
+func NewConsulProbe() (ConsulProbe, error) {
+	client, err := consul.NewClient(&consul.Config{
+		Address: consulAddress,
+		Scheme:  "http",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ConsulProbe(consulClient{Client: client}), nil
+}
+
+// WaitForServices waits for the healthy services count to equal the count
+// provided or it returns an error
+func (c consulClient) WaitForServices(service string, tag string, count int) error {
+	maxRetry := 30
+	retry := 0
+	var err error
+	for ; retry < maxRetry; retry++ {
+		if retry > 0 {
+			time.Sleep(1 * time.Second)
+		}
+		services, _, err := c.Client.Health().Service(service, tag, true, nil)
+		if err == nil && len(services) == count {
+			return nil
+		}
+	}
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("Service %s (tag:%s) count != %d", service, tag, count)
+}

--- a/integration_tests/fixtures/test_probe/src/docker.go
+++ b/integration_tests/fixtures/test_probe/src/docker.go
@@ -1,0 +1,38 @@
+package main
+
+import docker "github.com/samalba/dockerclient"
+
+const dockerSocket = "unix:///var/run/docker.sock"
+
+// DockerSignal is a signal that can be sent to a running container
+type DockerSignal string
+
+// Docker Signals
+const (
+	SigTerm = DockerSignal("TERM")
+	SigChld = DockerSignal("CHLD")
+	SigUsr1 = DockerSignal("USR1")
+	SigHup  = DockerSignal("HUP")
+)
+
+// DockerProbe is a test probe for docker
+type DockerProbe interface {
+	SendSignal(containerID string, signal DockerSignal) error
+}
+
+type dockerClient struct {
+	Client docker.Client
+}
+
+// NewDockerProbe creates a new DockerProbe for testing docker
+func NewDockerProbe() (DockerProbe, error) {
+	client, err := docker.NewDockerClient(dockerSocket, nil)
+	if err != nil {
+		return nil, err
+	}
+	return DockerProbe(dockerClient{Client: client}), nil
+}
+
+func (c dockerClient) SendSignal(containerID string, signal DockerSignal) error {
+	return c.Client.KillContainer(containerID, string(signal))
+}

--- a/integration_tests/fixtures/test_probe/src/main.go
+++ b/integration_tests/fixtures/test_probe/src/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+// TestCommand is a test that can be run by the probe
+type TestCommand func([]string) bool
+
+// AllTests maps a test name to its TestCommand function
+var AllTests map[string]TestCommand
+
+func runTest(testName string, args []string) {
+	// Register Tests
+	AllTests = map[string]TestCommand{
+		"test_sigterm":         TestSigterm,
+		"test_sighup_deadlock": TestSighupDeadlock,
+	}
+
+	if test := AllTests[testName]; test != nil {
+		args := os.Args[2:]
+		if success := test(args); success {
+			os.Exit(0)
+		}
+	}
+	os.Exit(1)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("Incorrect number of arguments. Expected TEST_NAME [ ARGUMENTS ... ]")
+	}
+	runTest(os.Args[1], os.Args[2:])
+}

--- a/integration_tests/fixtures/test_probe/src/test_sighup_deadlock.go
+++ b/integration_tests/fixtures/test_probe/src/test_sighup_deadlock.go
@@ -1,0 +1,51 @@
+package main
+
+import "log"
+import "time"
+import "math/rand"
+
+// TestSighupDeadlock regression test deadlock between
+// SIGUSR1 and SIGHUP: See GH-73
+func TestSighupDeadlock(args []string) bool {
+	if len(args) != 1 {
+		log.Println("TestSigterm requires 1 argument")
+		log.Println(" - containerID: docker container to kill")
+		return false
+	}
+
+	consul, err := NewConsulProbe()
+	if err != nil {
+		log.Println(err)
+	}
+	docker, err := NewDockerProbe()
+	if err != nil {
+		log.Println(err)
+	}
+
+	// Wait for 1 healthy 'app' service to be registered with consul
+	if err = consul.WaitForServices("app", "", 1); err != nil {
+		log.Printf("Expected app to be healthy before the test starts: %s\n", err)
+		return false
+	}
+
+	// Send it a SIGHUP a lot to try and force a deadlock
+	// 300x times with a random delay between each try
+	for i := 0; i < 300; i++ {
+		if err = docker.SendSignal(args[0], SigHup); err != nil {
+			log.Println(err)
+			return false
+		}
+		// Add some delay so that the config can reload
+		time.Sleep(time.Duration(rand.Int63n(30)) * time.Millisecond)
+	}
+
+	// Wait for TTL to expire
+	time.Sleep(6 * time.Second)
+
+	// Wait for app to be healthy
+	if err = consul.WaitForServices("app", "", 1); err != nil {
+		log.Printf("Expected app to be healthy after SIGHUP: %s\n", err)
+		return false
+	}
+	return true
+}

--- a/integration_tests/fixtures/test_probe/src/test_sigterm.go
+++ b/integration_tests/fixtures/test_probe/src/test_sigterm.go
@@ -1,0 +1,40 @@
+package main
+
+import "log"
+
+// TestSigterm tests that containerbuddy will deregister the service on a SIGTERM
+func TestSigterm(args []string) bool {
+	if len(args) != 1 {
+		log.Println("TestSigterm requires 1 argument")
+		log.Println(" - containerID: docker container to kill")
+		return false
+	}
+
+	consul, err := NewConsulProbe()
+	if err != nil {
+		log.Println(err)
+	}
+	docker, err := NewDockerProbe()
+	if err != nil {
+		log.Println(err)
+	}
+
+	// Wait for 1 healthy 'app' service to be registered with consul
+	if err = consul.WaitForServices("app", "", 1); err != nil {
+		log.Println(err)
+		return false
+	}
+
+	// Send it a SIGTERM
+	if err = docker.SendSignal(args[0], SigTerm); err != nil {
+		log.Println(err)
+		return false
+	}
+
+	// Wait for zero healthy 'app' services
+	if err = consul.WaitForServices("app", "", 0); err != nil {
+		log.Println(err)
+		return false
+	}
+	return true
+}

--- a/integration_tests/tests/test_sighup_deadlock/docker-compose.yml
+++ b/integration_tests/tests/test_sighup_deadlock/docker-compose.yml
@@ -1,0 +1,19 @@
+consul:
+    image: "cbfix_consul"
+    mem_limit: 256m
+    hostname: consul
+
+app:
+    image: "cbfix_app_consul"
+    mem_limit: 512m
+    links:
+      - consul:consul
+
+test:
+    image: "cbfix_test_probe"
+    mem_limit: 128m
+    links:
+      - consul:consul
+      - app:app
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock'

--- a/integration_tests/tests/test_sighup_deadlock/run.sh
+++ b/integration_tests/tests/test_sighup_deadlock/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+docker-compose up -d consul app > /dev/null 2>&1
+APP_ID="$(docker-compose ps -q app)"
+docker-compose run --no-deps test /go/bin/test_probe test_sighup_deadlock $APP_ID > /dev/null 2>&1
+result=$?
+TEST_ID=$(docker ps -l -f "ancestor=cbfix_test_probe" --format="{{.ID}}")
+docker logs $TEST_ID
+docker rm -f $TEST_ID > /dev/null 2>&1
+exit $result

--- a/integration_tests/tests/test_sigterm/docker-compose.yml
+++ b/integration_tests/tests/test_sigterm/docker-compose.yml
@@ -1,0 +1,21 @@
+consul:
+    image: "cbfix_consul"
+    mem_limit: 256m
+    hostname: consul
+
+app:
+    image: "cbfix_app_consul"
+    mem_limit: 512m
+    links:
+      - consul:consul
+    volumes:
+      - '${CONTAINERBUDDY_BIN}:/bin/containerbuddy:ro'
+
+test:
+    image: "cbfix_test_probe"
+    mem_limit: 128m
+    links:
+      - consul:consul
+      - app:app
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock'

--- a/integration_tests/tests/test_sigterm/run.sh
+++ b/integration_tests/tests/test_sigterm/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+docker-compose up -d consul app > /dev/null 2>&1
+APP_ID="$(docker-compose ps -q app)"
+docker-compose run --no-deps test /go/bin/test_probe test_sigterm $APP_ID > /dev/null 2>&1
+result=$?
+TEST_ID=$(docker ps -l -f "ancestor=cbfix_test_probe" --format="{{.ID}}")
+docker logs $TEST_ID
+docker rm -f $TEST_ID > /dev/null 2>&1
+exit $result

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 .SHELLFLAGS := -eu -o pipefail
 .DEFAULT_GOAL := build
 
-.PHONY: clean test consul etcd run-consul run-etcd example example-consul example-etcd ship dockerfile docker cover lint
+.PHONY: clean test integration consul etcd run-consul run-etcd example example-consul example-etcd ship dockerfile docker cover lint
 
 VERSION ?= dev-build-not-for-release
 LDFLAGS := '-X main.GitHash=$(shell git rev-parse --short HEAD) -X main.Version=${VERSION}'
@@ -30,6 +30,7 @@ clean:
 	docker rmi -f containerbuddy_build > /dev/null 2>&1 || true
 	docker rm -f containerbuddy_consul > /dev/null 2>&1 || true
 	docker rm -f containerbuddy_etcd > /dev/null 2>&1 || true
+	./test.sh clean
 
 # ----------------------------------------------
 # docker build
@@ -57,6 +58,9 @@ test: docker
 
 cover: docker
 	${DOCKERMAKE} cover
+
+integration: build docker
+	./test.sh
 
 # ------ Backends
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+DEBUG_LOG=${DEBUG_LOG:-"/dev/null"}
+ROOT_DIR="$DIR/integration_tests"
+FIXTURE_DIR="$ROOT_DIR/fixtures"
+TESTS_DIR="$ROOT_DIR/tests"
+
+if [ "$DEBUG_LOG" != "/dev/null" ]; then
+  DEBUG_LOG_DIR="$( cd "$( dirname "$DEBUG_LOG" )" && pwd )"
+  DEBUG_LOG="$DEBUG_LOG_DIR/$(basename $DEBUG_LOG)"
+fi
+
+die() {
+  echo "$@" | tee -a ${DEBUG_LOG} >&2
+  exit 1
+}
+
+log() {
+  echo "$(date '+%Y/%m/%d %H:%M:%S')" "$@" | tee -a ${DEBUG_LOG}
+}
+
+debug() {
+  echo "DEBUG - $(date '+%Y/%m/%d %H:%M:%S')" "$@" >> ${DEBUG_LOG}
+}
+
+banner() {
+  log "==== ${1} ===="
+}
+
+docker_running() {
+  local id=$(docker ps -q --filter="name=${1}")
+  [ -n "$id" ]
+}
+
+## Sanity Check
+if [ ! -d $FIXTURE_DIR ]; then die "Unable to find fixtures: $FIXTURE_DIR"; fi
+if [ ! -d $TESTS_DIR ];   then die "Unable to find tests: $TESTS_DIR"; fi
+
+DOCKER_IP=127.0.0.1
+if which docker-machine > /dev/null; then
+  DOCKER_MACHINE_ACTIVE=$(docker-machine active)
+  DOCKER_IP=$(docker-machine ip $DOCKER_MACHINE_ACTIVE)
+fi
+
+## Log settings
+export DOCKER_IP
+debug "DOCKER_IP=$DOCKER_IP"
+
+export FIXTURE_PREFIX=${FIXTURE_PREFIX:-"cbfix_"}
+debug "FIXTURE_PREFIX=$FIXTURE_PREFIX"
+
+debug "ROOT_DIR=$ROOT_DIR"
+debug "FIXTURE_DIR=$FIXTURE_DIR"
+debug "TESTS_DIR=$TESTS_DIR"
+
+## Main Code
+
+create_test_fixtures() {
+  banner "Create Test Fixtures"
+  if [ ! -f "$DIR/build/containerbuddy" ]; then die "Containerbuddy not built. Did you make?"; fi
+  find $FIXTURE_DIR -maxdepth 1 -mindepth 1 -type d | \
+    sort | \
+    while read FDIR; do
+      FNAME="${FIXTURE_PREFIX}$(basename $FDIR)"
+      rm -rf $FDIR/build
+      cp -r $DIR/build $FDIR/build
+      cd $FDIR
+      if [ -z "$(docker images -q $FNAME)" ]; then
+        log "Create fixture $FNAME"
+        docker build -t $FNAME --no-cache=false . 2>&1 >> ${DEBUG_LOG}
+        rm -rf $FDIR/build
+      else
+        log "Skipping Fixture $FNAME ... already exists"
+      fi
+  done
+}
+
+destroy_test_fixtures() {
+    banner "Destroying Test Fixtures"
+    find $FIXTURE_DIR -maxdepth 1 -mindepth 1 -type d |\
+      while read FDIR; do
+        FNAME="${FIXTURE_PREFIX}$(basename $FDIR)"
+        if [ -n "$(docker images -q $FNAME)" ]; then
+          log "Remove Fixture fixture $FNAME"
+          docker ps -q --filter "ancestor=${FNAME}" | while read CONTAINER_ID; do
+            log " - Killing $CONTAINER_ID"
+            docker rm --force $CONTAINER_ID >> ${DEBUG_LOG} 2>&1
+          done
+          docker rmi --force $FNAME >> ${DEBUG_LOG} 2>&1
+          rm -rf $FDIR/build
+        fi
+    done
+}
+
+build_test_compose() {
+  if [ -r "$COMPOSE_FILE" ]; then
+    docker-compose build >> ${DEBUG_LOG} 2>&1
+  fi
+}
+
+destroy_test_compose() {
+  if [ -r "$COMPOSE_FILE" ]; then
+    docker-compose kill >> ${DEBUG_LOG} 2>&1
+    docker-compose rm -f >> ${DEBUG_LOG} 2>&1
+  fi
+}
+
+run_test() {
+  TDIR=$1
+  if [ ! -r "$TDIR/run.sh" ]; then
+    log "WARN - No run.sh found in $TDIR"
+  else
+    cd $TDIR
+    export COMPOSE_PROJECT_NAME="$(basename $TDIR)"
+    export COMPOSE_FILE="./docker-compose.yml"
+    export CONTAINERBUDDY_BIN="$DIR/build/containerbuddy"
+    log "TEST: $COMPOSE_PROJECT_NAME"
+    build_test_compose
+    chmod 755 "./run.sh"
+    if ./run.sh; then
+      log "PASS: $COMPOSE_PROJECT_NAME"
+    else
+      log "FAIL: $COMPOSE_PROJECT_NAME"
+      echo $COMPOSE_PROJECT_NAME >> "$FAILED"
+    fi
+    destroy_test_compose
+  fi
+}
+
+run_tests() {
+  banner "Running Integration Tests"
+  FAILED=$TESTS_DIR/failed.log
+  rm -f $FAILED
+  TARGET="$1"
+  if [ -z "$TARGET" ]; then
+    ## Run All Tests
+    for TDIR in $(find $TESTS_DIR -maxdepth 1 -mindepth 1 -type d ); do
+      run_test $TDIR
+    done
+  else
+    ## Run specific test
+    TDIR=$(find $TESTS_DIR -maxdepth 1 -mindepth 1 -type d -name $TARGET)
+    run_test $TDIR
+  fi
+  [ ! -r "$FAILED" ]
+}
+
+clean_tests() {
+  find $TESTS_DIR -maxdepth 1 -mindepth 1 -type d |\
+    while read TDIR; do
+      cd $TDIR
+      export COMPOSE_PROJECT_NAME="$(basename $TDIR)"
+      export COMPOSE_FILE="./docker-compose.yml"
+      destroy_test_compose
+    done
+}
+
+COMMAND=${1:-"test"}
+shift
+case $COMMAND in
+  test)
+    create_test_fixtures
+    run_tests "$1"
+    result=$?
+    clean_tests
+    if [ $result -ne 0 ]; then
+      banner "Tests Failed!"
+      exit 1
+    fi
+  ;;
+  clean)
+    destroy_test_fixtures
+    clean_tests
+  ;;
+esac


### PR DESCRIPTION
For #67 

Still a work in progress, but it's finally working for me in TravisCI.  

- There is a [README.md](https://github.com/justenwalker/containerbuddy/blob/integration_tests/integration_tests/README.md) in the integration_tests folder which describes how it operates and how to make tests.
- I've made an example test for SIGTERM. It's small golang application called [test_probe](https://github.com/justenwalker/containerbuddy/tree/integration_tests/integration_tests/fixtures/test_probe). It can be extended to support other tests easily - reducing the amount of bash wizardry needed to write tests.
- Added a test for #74 (but forced it to pass)