### PR TITLE
Add --force flag to container tagging in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -133,10 +133,10 @@ clean-etcd:
 
 # tag and ship example to Docker Hub registry
 ship: example
-	docker tag ${COMPOSE_PREFIX_CONSUL}_nginx 0x74696d/containerbuddy-demo-nginx
-	docker tag ${COMPOSE_PREFIX_CONSUL}_app 0x74696d/containerbuddy-demo-app
-	docker tag ${COMPOSE_PREFIX_ETCD}_nginx 0x74696d/containerbuddy-etcd-demo-nginx
-	docker tag ${COMPOSE_PREFIX_ETCD}_app 0x74696d/containerbuddy-etcd-demo-app
+	docker tag -f ${COMPOSE_PREFIX_CONSUL}_nginx 0x74696d/containerbuddy-demo-nginx
+	docker tag -f ${COMPOSE_PREFIX_CONSUL}_app 0x74696d/containerbuddy-demo-app
+	docker tag -f ${COMPOSE_PREFIX_ETCD}_nginx 0x74696d/containerbuddy-etcd-demo-nginx
+	docker tag -f ${COMPOSE_PREFIX_ETCD}_app 0x74696d/containerbuddy-etcd-demo-app
 	docker push 0x74696d/containerbuddy-demo-nginx
 	docker push 0x74696d/containerbuddy-demo-app
 	docker push 0x74696d/containerbuddy-etcd-demo-nginx


### PR DESCRIPTION
During releases, if there are existing local builds of the example containers then the tags won't be pushed to the Hub until the old builds are cleared up locally. This overrides this behavior. (The local copies of example container images aren't something we care about as build artifacts in-and-of-themselves.)

cc @misterbisson @justenwalker 