### PR TITLE
Update package path for LDFLAGS

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ SHELL := /bin/bash
 .PHONY: clean test integration consul etcd run-consul run-etcd example example-consul example-etcd ship dockerfile docker cover lint
 
 VERSION ?= dev-build-not-for-release
-LDFLAGS := '-X containerbuddy.GitHash=$(shell git rev-parse --short HEAD) -X containerbuddy.Version=${VERSION}'
+LDFLAGS := '-X github.com/joyent/containerbuddy/containerbuddy.GitHash=$(shell git rev-parse --short HEAD) -X github.com/joyent/containerbuddy/containerbuddy.Version=${VERSION}'
 
 ROOT := $(shell pwd)
 PACKAGE := github.com/joyent/containerbuddy


### PR DESCRIPTION
For https://github.com/joyent/containerbuddy/issues/85

We need to have the fully-qualified path in the LDFLAGS in order to have it injected into the package's variables.

@misterbisson or @justenwalker to review please.