### PR TITLE
Implement Log Levels with Logrus

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,10 +1,12 @@
 {
 	"ImportPath": "github.com/joyent/containerbuddy",
 	"GoVersion": "go1.5",
-	"Packages": [
-		"./..."
-	],
 	"Deps": [
+		{
+			"ImportPath": "github.com/Sirupsen/logrus",
+			"Comment": "v0.9.0",
+			"Rev": "be52937128b38f1d99787bb476c789e2af1147f1"
+		},
 		{
 			"ImportPath": "github.com/coreos/etcd/Godeps/_workspace/src/github.com/ugorji/go/codec",
 			"Comment": "v2.2.5-1-g6bc9b6e",
@@ -31,22 +33,17 @@
 			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
 		},
 		{
-			"ImportPath": "github.com/docker/go-units",
-			"Comment": "v0.1.0-23-g5d2041e",
-			"Rev": "5d2041e26a699eaca682e2ea41c8f891e1060444"
-		},
-		{
 			"ImportPath": "github.com/hashicorp/consul/api",
 			"Comment": "v0.5.2-461-g158eabd",
 			"Rev": "158eabdd6f2408067c1d7656fa10e49434f96480"
 		},
 		{
-			"ImportPath": "github.com/samalba/dockerclient",
-			"Rev": "4278ba330b9475a8fa85520226479697f6c84482"
-		},
-		{
 			"ImportPath": "golang.org/x/net/context",
 			"Rev": "7f88271ea9913b72aca44fa7fc8af919eacc17ce"
+		},
+		{
+			"ImportPath": "golang.org/x/sys/unix",
+			"Rev": "50c6bc5e4292a1d4e65c6e9be5f53be28bcbe28e"
 		}
 	]
 }

--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ Must supply only one of the following
     - `endpoints` is the list of etcd nodes in your cluster
     - `prefix` is the path that will be prefixed to all service discovery keys. This key is optional. (Default: `/containerbuddy`)
 
-Logging Config:
+Logging Config (Optional):
 
 The logging config adjust the output format and verbosity of Containerbuddy logs.
 
-- `level` adjusts the verbosity of the messages output by containerbuddy. Must be one of: DEBUG, INFO, WARN, ERROR, FATAL, PANIC (Default: INFO)
-- `format` adjust the output format for log messages. Can be "go", "text", or "json" (Default: "go")
-- `output` picks the output stream for log messages. Can be "stderr" or "stdout" (Default: "stdout")
+- `level` adjusts the verbosity of the messages output by containerbuddy. Must be one of: `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`, `PANIC` (Default is `INFO`)
+- `format` adjust the output format for log messages. Can be `go`, `text`, or `json` (Default is `go`)
+- `output` picks the output stream for log messages. Can be `stderr` or `stdout` (Default is `stdout`)
 
 Other fields:
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,47 @@ Logging Config (Optional):
 The logging config adjust the output format and verbosity of Containerbuddy logs.
 
 - `level` adjusts the verbosity of the messages output by containerbuddy. Must be one of: `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`, `PANIC` (Default is `INFO`)
-- `format` adjust the output format for log messages. Can be `go`, `text`, or `json` (Default is `go`)
+- `format` adjust the output format for log messages. Can be `default`, `text`, or `json` (Default is `default`)
 - `output` picks the output stream for log messages. Can be `stderr` or `stdout` (Default is `stdout`)
+
+Logging Format Examples:
+
+`default` - go log package with [LstdFlags](https://golang.org/pkg/log/)
+
+```
+2015/03/26 01:27:38 Started observing beach
+2015/03/26 01:27:38 A group of walrus emerges from the ocean
+2015/03/26 01:27:38 The group's number increased tremendously!
+2015/03/26 01:27:38 Temperature changes
+2015/03/26 01:27:38 It's over 9000!
+2015/03/26 01:27:38 The ice breaks!
+```
+
+`text` - [logrus TextFormatter](https://github.com/Sirupsen/logrus)
+
+```
+time="2015-03-26T01:27:38-04:00" level=debug msg="Started observing beach" animal=walrus number=8
+time="2015-03-26T01:27:38-04:00" level=info msg="A group of walrus emerges from the ocean" animal=walrus size=10
+time="2015-03-26T01:27:38-04:00" level=warning msg="The group's number increased tremendously!" number=122 omg=true
+time="2015-03-26T01:27:38-04:00" level=debug msg="Temperature changes" temperature=-4
+time="2015-03-26T01:27:38-04:00" level=panic msg="It's over 9000!" animal=orca size=9009
+time="2015-03-26T01:27:38-04:00" level=fatal msg="The ice breaks!" err=&{0x2082280c0 map[animal:orca size:9009] 2015-03-26 01:27:38.441574009 -0400 EDT panic It's over 9000!} number=100 omg=true
+exit status 1
+```
+
+`json` - [logrus JSONFormatter](https://github.com/Sirupsen/logrus)
+
+```
+{"animal":"walrus","level":"info","msg":"A group of walrus emerges from the ocean","size":10,"time":"2014-03-10 19:57:38.562264131 -0400 EDT"}
+
+{"level":"warning","msg":"The group's number increased tremendously!","number":122,"omg":true,"time":"2014-03-10 19:57:38.562471297 -0400 EDT"}
+
+{"animal":"walrus","level":"info","msg":"A giant walrus appears!","size":10,"time":"2014-03-10 19:57:38.562500591 -0400 EDT"}
+
+{"animal":"walrus","level":"info","msg":"Tremendously sized cow enters the ocean.","size":9,"time":"2014-03-10 19:57:38.562527896 -0400 EDT"}
+
+{"level":"fatal","msg":"The ice breaks!","number":100,"omg":true,"time":"2014-03-10 19:57:38.562543128 -0400 EDT"}
+```
 
 Other fields:
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ The format of the JSON file configuration is as follows:
 {
   "consul": "consul:8500",
   "onStart": "/opt/containerbuddy/onStart-script.sh {{.ENV_VAR_NAME}}",
+  "logging": {
+    "level": "INFO",
+    "format": "go",
+    "output": "stdout"
+  },
   "stopTimeout": 5,
   "preStop": "/opt/containerbuddy/preStop-script.sh",
   "postStop": "/opt/containerbuddy/postStop-script.sh",
@@ -128,6 +133,14 @@ Must supply only one of the following
 
     - `endpoints` is the list of etcd nodes in your cluster
     - `prefix` is the path that will be prefixed to all service discovery keys. This key is optional. (Default: `/containerbuddy`)
+
+Logging Config:
+
+The logging config adjust the output format and verbosity of Containerbuddy logs.
+
+- `level` adjusts the verbosity of the messages output by containerbuddy. Must be one of: DEBUG, INFO, WARN, ERROR, FATAL, PANIC (Default: INFO)
+- `format` adjust the output format for log messages. Can be "go", "text", or "json" (Default: "go")
+- `output` picks the output stream for log messages. Can be "stderr" or "stdout" (Default: "stdout")
 
 Other fields:
 

--- a/containerbuddy/config.go
+++ b/containerbuddy/config.go
@@ -41,6 +41,7 @@ func getConfig() *Config {
 type Config struct {
 	Consul       string                 `json:"consul,omitempty"`
 	Etcd         map[string]interface{} `json:"etcd,omitempty"`
+	LogConfig    *LogConfig             `json:"logging,omitempty"`
 	OnStart      json.RawMessage        `json:"onStart,omitempty"`
 	PreStop      json.RawMessage        `json:"preStop,omitempty"`
 	PostStop     json.RawMessage        `json:"postStop,omitempty"`
@@ -241,6 +242,13 @@ func initializeConfig(config *Config) (*Config, error) {
 		return nil, errors.New("No discovery backend defined")
 	} else if discoveryCount > 1 {
 		return nil, errors.New("More than one discovery backend defined")
+	}
+
+	if config.LogConfig != nil {
+		err := config.LogConfig.init()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if config.StopTimeout == 0 {

--- a/containerbuddy/consul.go
+++ b/containerbuddy/consul.go
@@ -36,7 +36,7 @@ func (c Consul) Deregister(service *ServiceConfig) {
 // MarkForMaintenance removes the node from Consul.
 func (c Consul) MarkForMaintenance(service *ServiceConfig) {
 	if err := c.Agent().ServiceDeregister(service.ID); err != nil {
-		log.Printf("Deregistering failed: %s\n", err)
+		log.Infof("Deregistering failed: %s\n", err)
 	}
 }
 
@@ -45,12 +45,12 @@ func (c Consul) MarkForMaintenance(service *ServiceConfig) {
 // its TTL check.
 func (c Consul) SendHeartbeat(service *ServiceConfig) {
 	if err := c.Agent().PassTTL(service.ID, "ok"); err != nil {
-		log.Printf("%v\nService not registered, registering...", err)
+		log.Infof("%v\nService not registered, registering...", err)
 		if err = c.registerService(*service); err != nil {
-			log.Printf("Service registration failed: %s\n", err)
+			log.Warnf("Service registration failed: %s\n", err)
 		}
 		if err = c.registerCheck(*service); err != nil {
-			log.Printf("Check registration failed: %s\n", err)
+			log.Warnf("Check registration failed: %s\n", err)
 		}
 	}
 }
@@ -91,7 +91,7 @@ func (c Consul) CheckForUpstreamChanges(backend *BackendConfig) bool {
 func (c *Consul) checkHealth(backend BackendConfig) bool {
 	services, meta, err := c.Health().Service(backend.Name, backend.Tag, true, nil)
 	if err != nil {
-		log.Printf("Failed to query %v: %s [%v]", backend.Name, err, meta)
+		log.Warnf("Failed to query %v: %s [%v]", backend.Name, err, meta)
 		return false
 	}
 	didChange := compareForChange(upstreams[backend.Name], services)

--- a/containerbuddy/consul.go
+++ b/containerbuddy/consul.go
@@ -2,10 +2,10 @@ package containerbuddy
 
 import (
 	"fmt"
-	"log"
-	"sort"
 	"os"
+	"sort"
 
+	log "github.com/Sirupsen/logrus"
 	consul "github.com/hashicorp/consul/api"
 )
 

--- a/containerbuddy/consul.go
+++ b/containerbuddy/consul.go
@@ -36,7 +36,7 @@ func (c Consul) Deregister(service *ServiceConfig) {
 // MarkForMaintenance removes the node from Consul.
 func (c Consul) MarkForMaintenance(service *ServiceConfig) {
 	if err := c.Agent().ServiceDeregister(service.ID); err != nil {
-		log.Infof("Deregistering failed: %s\n", err)
+		log.Infof("Deregistering failed: %s", err)
 	}
 }
 
@@ -47,10 +47,10 @@ func (c Consul) SendHeartbeat(service *ServiceConfig) {
 	if err := c.Agent().PassTTL(service.ID, "ok"); err != nil {
 		log.Infof("%v\nService not registered, registering...", err)
 		if err = c.registerService(*service); err != nil {
-			log.Warnf("Service registration failed: %s\n", err)
+			log.Warnf("Service registration failed: %s", err)
 		}
 		if err = c.registerCheck(*service); err != nil {
-			log.Warnf("Check registration failed: %s\n", err)
+			log.Warnf("Check registration failed: %s", err)
 		}
 	}
 }

--- a/containerbuddy/etcd.go
+++ b/containerbuddy/etcd.go
@@ -2,7 +2,6 @@ package containerbuddy
 
 import (
 	"fmt"
-	"log"
 	"sort"
 	"time"
 
@@ -10,6 +9,8 @@ import (
 
 	"github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // Etcd is a service discovery backend for CoreOS etcd

--- a/containerbuddy/ips.go
+++ b/containerbuddy/ips.go
@@ -3,12 +3,13 @@ package containerbuddy
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"net"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // GetIP determines the IP address of the container

--- a/containerbuddy/ips.go
+++ b/containerbuddy/ips.go
@@ -42,7 +42,7 @@ func GetIP(specList []string) (string, error) {
 	 * recoverable. Let's pass on the parsed interfaces and log the error
 	 * state. */
 	if interfaceIPsErr != nil && len(interfaceIPs) > 0 {
-		log.Printf("We had a problem reading information about some network "+
+		log.Warnf("We had a problem reading information about some network "+
 			"interfaces. If everything works, it is safe to ignore this "+
 			"message. Details:\n%s\n", interfaceIPsErr)
 	}
@@ -137,7 +137,7 @@ func parseInterfaceSpecs(interfaces []string) ([]interfaceSpec, error) {
 	}
 	if len(errors) > 0 {
 		err := fmt.Errorf(strings.Join(errors, "\n"))
-		log.Println(err.Error())
+		log.Errorln(err)
 		return specs, err
 	}
 	return specs, nil
@@ -245,7 +245,7 @@ func getinterfaceIPs(interfaces []net.Interface) ([]interfaceIP, error) {
 	 * then return them so that the caller can decide what they want to do. */
 	if len(errors) > 0 {
 		err := fmt.Errorf(strings.Join(errors, "\n"))
-		log.Println(err.Error())
+		log.Errorln(err)
 		return ifaceIPs, err
 	}
 

--- a/containerbuddy/logging.go
+++ b/containerbuddy/logging.go
@@ -20,7 +20,7 @@ type LogConfig struct {
 
 var defaultLog = &LogConfig{
 	Level:  "INFO",
-	Format: "go",
+	Format: "default",
 	Output: "stdout",
 }
 
@@ -52,8 +52,8 @@ func (l *LogConfig) init() error {
 		formatter = &logrus.TextFormatter{}
 	case "json":
 		formatter = &logrus.JSONFormatter{}
-	case "go":
-		formatter = &GoLogFormatter{}
+	case "default":
+		formatter = &DefaultLogFormatter{}
 	default:
 		return fmt.Errorf("Unknown log format '%s'", l.Format)
 	}
@@ -71,12 +71,12 @@ func (l *LogConfig) init() error {
 	return nil
 }
 
-// GoLogFormatter delegates formatting to standard go log package
-type GoLogFormatter struct {
+// DefaultLogFormatter delegates formatting to standard go log package
+type DefaultLogFormatter struct {
 }
 
 // Format formats the logrus entry by passing it to the "log" package
-func (f *GoLogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+func (f *DefaultLogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	b := &bytes.Buffer{}
 	logger := log.New(b, "", log.LstdFlags)
 	switch entry.Level {

--- a/containerbuddy/logging.go
+++ b/containerbuddy/logging.go
@@ -1,0 +1,92 @@
+package containerbuddy
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// LogConfig configures the log levels
+type LogConfig struct {
+	Level  string `json:"level"`
+	Format string `json:"format,omitempty"`
+	Output string `json:"output,omitempty"`
+}
+
+var defaultLog = &LogConfig{
+	Level:  "INFO",
+	Format: "go",
+	Output: "stdout",
+}
+
+func init() {
+	if err := defaultLog.init(); err != nil {
+		log.Println(err)
+	}
+}
+
+func (l *LogConfig) init() error {
+	// Set defaults
+	if l.Level == "" {
+		l.Level = defaultLog.Level
+	}
+	if l.Format == "" {
+		l.Format = defaultLog.Format
+	}
+	if l.Output == "" {
+		l.Output = defaultLog.Output
+	}
+	level, err := logrus.ParseLevel(strings.ToLower(l.Level))
+	if err != nil {
+		return fmt.Errorf("Unknown log level '%s': %s", l.Level, err)
+	}
+	var formatter logrus.Formatter
+	var output io.Writer
+	switch strings.ToLower(l.Format) {
+	case "text":
+		formatter = &logrus.TextFormatter{}
+	case "json":
+		formatter = &logrus.JSONFormatter{}
+	case "go":
+		formatter = &GoLogFormatter{}
+	default:
+		return fmt.Errorf("Unknown log format '%s'", l.Format)
+	}
+	switch strings.ToLower(l.Output) {
+	case "stderr":
+		output = os.Stderr
+	case "stdout":
+		output = os.Stdout
+	default:
+		return fmt.Errorf("Unknown output type '%s'", l.Output)
+	}
+	log.Printf("=== SET FORMAT ===\n%#v\n", formatter)
+	logrus.SetLevel(level)
+	logrus.SetFormatter(formatter)
+	logrus.SetOutput(output)
+	return nil
+}
+
+// GoLogFormatter delegates formatting to standard go log package
+type GoLogFormatter struct {
+}
+
+// Format formats the logrus entry by passing it to the "log" package
+func (f *GoLogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	b := &bytes.Buffer{}
+	logger := log.New(b, "", log.LstdFlags)
+	switch entry.Level {
+	case logrus.PanicLevel:
+		logger.Panicln(entry.Message)
+	case logrus.FatalLevel:
+		logger.Fatalln(entry.Message)
+	default:
+		logger.Println(entry.Message)
+	}
+	return b.Bytes(), nil
+}

--- a/containerbuddy/logging.go
+++ b/containerbuddy/logging.go
@@ -65,7 +65,6 @@ func (l *LogConfig) init() error {
 	default:
 		return fmt.Errorf("Unknown output type '%s'", l.Output)
 	}
-	log.Printf("=== SET FORMAT ===\n%#v\n", formatter)
 	logrus.SetLevel(level)
 	logrus.SetFormatter(formatter)
 	logrus.SetOutput(output)

--- a/containerbuddy/logging_test.go
+++ b/containerbuddy/logging_test.go
@@ -1,0 +1,42 @@
+package containerbuddy
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+)
+
+func TestLoggingBootstrap(t *testing.T) {
+	//Logging should be initialized when the package loads
+	std := logrus.StandardLogger()
+	if std.Level != logrus.InfoLevel {
+		t.Errorf("Expected INFO level logs, but got: %s", std.Level)
+	}
+	if std.Out != os.Stdout {
+		t.Errorf("Expected output to Stdout")
+	}
+	if _, ok := std.Formatter.(*GoLogFormatter); !ok {
+		t.Errorf("Expected *containerbuddy.GoLogFormatter got: %v", reflect.TypeOf(std.Formatter))
+	}
+}
+
+func TestLoggingConfigInit(t *testing.T) {
+	testLog := &LogConfig{
+		Level:  "DEBUG",
+		Format: "text",
+		Output: "stderr",
+	}
+	testLog.init()
+	std := logrus.StandardLogger()
+	if std.Level != logrus.DebugLevel {
+		t.Errorf("Expected 'debug' level logs, but got: %s", std.Level)
+	}
+	if std.Out != os.Stderr {
+		t.Errorf("Expected output to Stderr")
+	}
+	if _, ok := std.Formatter.(*logrus.TextFormatter); !ok {
+		t.Errorf("Expected *logrus.TextFormatter got: %v", reflect.TypeOf(std.Formatter))
+	}
+}

--- a/containerbuddy/logging_test.go
+++ b/containerbuddy/logging_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestLoggingBootstrap(t *testing.T) {
-	//Logging should be initialized when the package loads
+	defaultLog.init()
 	std := logrus.StandardLogger()
 	if std.Level != logrus.InfoLevel {
 		t.Errorf("Expected INFO level logs, but got: %s", std.Level)
@@ -39,4 +39,6 @@ func TestLoggingConfigInit(t *testing.T) {
 	if _, ok := std.Formatter.(*logrus.TextFormatter); !ok {
 		t.Errorf("Expected *logrus.TextFormatter got: %v", reflect.TypeOf(std.Formatter))
 	}
+	// Reset to defaults
+	defaultLog.init()
 }

--- a/containerbuddy/logging_test.go
+++ b/containerbuddy/logging_test.go
@@ -17,8 +17,8 @@ func TestLoggingBootstrap(t *testing.T) {
 	if std.Out != os.Stdout {
 		t.Errorf("Expected output to Stdout")
 	}
-	if _, ok := std.Formatter.(*GoLogFormatter); !ok {
-		t.Errorf("Expected *containerbuddy.GoLogFormatter got: %v", reflect.TypeOf(std.Formatter))
+	if _, ok := std.Formatter.(*DefaultLogFormatter); !ok {
+		t.Errorf("Expected *containerbuddy.DefaultLogFormatter got: %v", reflect.TypeOf(std.Formatter))
 	}
 }
 

--- a/containerbuddy/main.go
+++ b/containerbuddy/main.go
@@ -2,12 +2,13 @@ package containerbuddy
 
 import (
 	"flag"
-	"log"
 	"os"
 	"os/exec"
 	"runtime"
 	"syscall"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // Main executes the containerbuddy CLI

--- a/containerbuddy/main.go
+++ b/containerbuddy/main.go
@@ -41,7 +41,7 @@ func Main() {
 		config.Command = argsToCmd(flag.Args())
 		code, err := executeAndWait(config.Command)
 		if err != nil {
-			log.Println(err)
+			log.Errorln(err)
 		}
 		// Run the PostStop handler, if any, and exit if it returns an error
 		if postStopCode, err := run(getConfig().postStopCmd); err != nil {
@@ -126,7 +126,7 @@ func executeAndWait(cmd *exec.Cmd) (int, error) {
 		// serious problem with the underlying open/exec syscalls. But
 		// we'll let the lack of heartbeat tell us if something has gone
 		// wrong to that extent.
-		log.Println(err)
+		log.Errorln(err)
 		return 1, err
 	}
 	return 0, nil
@@ -138,7 +138,7 @@ func executeAndWait(cmd *exec.Cmd) (int, error) {
 func run(cmd *exec.Cmd) (int, error) {
 	code, err := executeAndWait(cmd)
 	if err != nil {
-		log.Println(err)
+		log.Errorln(err)
 	}
 	return code, err
 }

--- a/containerbuddy/signals.go
+++ b/containerbuddy/signals.go
@@ -31,7 +31,7 @@ func toggleMaintenanceMode(config *Config) {
 	paused = !paused
 	if paused {
 		forAllServices(config, func(service *ServiceConfig) {
-			log.Infof("Marking for maintenance: %s\n", service.Name)
+			log.Infof("Marking for maintenance: %s", service.Name)
 			service.MarkForMaintenance()
 		})
 	}
@@ -42,7 +42,7 @@ func terminate(config *Config) {
 	defer signalLock.Unlock()
 	stopPolling(config)
 	forAllServices(config, func(service *ServiceConfig) {
-		log.Infof("Deregistering service: %s\n", service.Name)
+		log.Infof("Deregistering service: %s", service.Name)
 		service.Deregister()
 	})
 
@@ -56,33 +56,33 @@ func terminate(config *Config) {
 	}
 	if config.StopTimeout > 0 {
 		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
-			log.Warnf("Error sending SIGTERM to application: %s\n", err)
+			log.Warnf("Error sending SIGTERM to application: %s", err)
 		} else {
 			time.AfterFunc(time.Duration(config.StopTimeout)*time.Second, func() {
-				log.Infof("Killing Process %#v\n", cmd.Process)
+				log.Infof("Killing Process %#v", cmd.Process)
 				cmd.Process.Kill()
 			})
 			return
 		}
 	}
-	log.Infof("Killing Process %#v\n", config.Command.Process)
+	log.Infof("Killing Process %#v", config.Command.Process)
 	cmd.Process.Kill()
 }
 
 func reloadConfig(config *Config) *Config {
 	signalLock.Lock()
 	defer signalLock.Unlock()
-	log.Infof("Reloading configuration.\n")
+	log.Infof("Reloading configuration.")
 	newConfig, err := loadConfig()
 	if err != nil {
-		log.Errorf("Could not reload config: %v\n", err)
+		log.Errorf("Could not reload config: %v", err)
 		return nil
 	}
 	// stop advertising the existing services so that we can
 	// make sure we update them if ports, etc. change.
 	stopPolling(config)
 	forAllServices(config, func(service *ServiceConfig) {
-		log.Infof("Deregistering service: %s\n", service.Name)
+		log.Infof("Deregistering service: %s", service.Name)
 		service.Deregister()
 	})
 

--- a/containerbuddy/signals.go
+++ b/containerbuddy/signals.go
@@ -75,7 +75,7 @@ func reloadConfig(config *Config) *Config {
 	log.Infof("Reloading configuration.\n")
 	newConfig, err := loadConfig()
 	if err != nil {
-		log.Warnf("Could not reload config: %v\n", err)
+		log.Errorf("Could not reload config: %v\n", err)
 		return nil
 	}
 	// stop advertising the existing services so that we can

--- a/containerbuddy/signals.go
+++ b/containerbuddy/signals.go
@@ -1,12 +1,13 @@
 package containerbuddy
 
 import (
-	"log"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // globals are eeeeevil

--- a/containerbuddy/signals.go
+++ b/containerbuddy/signals.go
@@ -31,7 +31,7 @@ func toggleMaintenanceMode(config *Config) {
 	paused = !paused
 	if paused {
 		forAllServices(config, func(service *ServiceConfig) {
-			log.Printf("Marking for maintenance: %s\n", service.Name)
+			log.Infof("Marking for maintenance: %s\n", service.Name)
 			service.MarkForMaintenance()
 		})
 	}
@@ -42,7 +42,7 @@ func terminate(config *Config) {
 	defer signalLock.Unlock()
 	stopPolling(config)
 	forAllServices(config, func(service *ServiceConfig) {
-		log.Printf("Deregistering service: %s\n", service.Name)
+		log.Infof("Deregistering service: %s\n", service.Name)
 		service.Deregister()
 	})
 
@@ -56,33 +56,33 @@ func terminate(config *Config) {
 	}
 	if config.StopTimeout > 0 {
 		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
-			log.Printf("Error sending SIGTERM to application: %s\n", err)
+			log.Warnf("Error sending SIGTERM to application: %s\n", err)
 		} else {
 			time.AfterFunc(time.Duration(config.StopTimeout)*time.Second, func() {
-				log.Printf("Killing Process %#v\n", cmd.Process)
+				log.Infof("Killing Process %#v\n", cmd.Process)
 				cmd.Process.Kill()
 			})
 			return
 		}
 	}
-	log.Printf("Killing Process %#v\n", config.Command.Process)
+	log.Infof("Killing Process %#v\n", config.Command.Process)
 	cmd.Process.Kill()
 }
 
 func reloadConfig(config *Config) *Config {
 	signalLock.Lock()
 	defer signalLock.Unlock()
-	log.Printf("Reloading configuration.\n")
+	log.Infof("Reloading configuration.\n")
 	newConfig, err := loadConfig()
 	if err != nil {
-		log.Printf("Could not reload config: %v\n", err)
+		log.Warnf("Could not reload config: %v\n", err)
 		return nil
 	}
 	// stop advertising the existing services so that we can
 	// make sure we update them if ports, etc. change.
 	stopPolling(config)
 	forAllServices(config, func(service *ServiceConfig) {
-		log.Printf("Deregistering service: %s\n", service.Name)
+		log.Infof("Deregistering service: %s\n", service.Name)
 		service.Deregister()
 	})
 


### PR DESCRIPTION
For #88

I tried to keep this as backwards compatible as possible by default - basically by delegating the default log formatter to the built-in log package targeting Stdout.

- Add Logrus as the logging framework
- Create "logging" config and add to README
- Add backwards-compatible "go" log format as the default
- Support "text" and "json" output formats
- Support "stderr" and "stdout" output target (Default stdout)

Since the output is going to a non TTY source, the TextFormatter is just a list of key=value entries - Not especially human readable. I suppose people could continue to use the default to the "go" format for a human readable output.

Also, Logrus has a "logstash" output formatter - although I'm not so sure we want such a specialized formatter.