### PR TITLE
etcd: parse array endpoints correctly

### DIFF
--- a/containerbuddy/config.go
+++ b/containerbuddy/config.go
@@ -39,15 +39,15 @@ func getConfig() *Config {
 
 // Config is the top-level Containerbuddy Configuration
 type Config struct {
-	Consul       string                 `json:"consul,omitempty"`
-	Etcd         map[string]interface{} `json:"etcd,omitempty"`
-	LogConfig    *LogConfig             `json:"logging,omitempty"`
-	OnStart      json.RawMessage        `json:"onStart,omitempty"`
-	PreStop      json.RawMessage        `json:"preStop,omitempty"`
-	PostStop     json.RawMessage        `json:"postStop,omitempty"`
-	StopTimeout  int                    `json:"stopTimeout"`
-	Services     []*ServiceConfig       `json:"services"`
-	Backends     []*BackendConfig       `json:"backends"`
+	Consul       string           `json:"consul,omitempty"`
+	Etcd         json.RawMessage  `json:"etcd,omitempty"`
+	LogConfig    *LogConfig       `json:"logging,omitempty"`
+	OnStart      json.RawMessage  `json:"onStart,omitempty"`
+	PreStop      json.RawMessage  `json:"preStop,omitempty"`
+	PostStop     json.RawMessage  `json:"postStop,omitempty"`
+	StopTimeout  int              `json:"stopTimeout"`
+	Services     []*ServiceConfig `json:"services"`
+	Backends     []*BackendConfig `json:"backends"`
 	onStartCmd   *exec.Cmd
 	preStopCmd   *exec.Cmd
 	postStopCmd  *exec.Cmd

--- a/containerbuddy/etcd_test.go
+++ b/containerbuddy/etcd_test.go
@@ -1,14 +1,14 @@
 package containerbuddy
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 )
 
 func setupEtcd(serviceName string) *Config {
-	etcd := NewEtcdConfig(map[string]interface{}{
-		"endpoints": []string{"http://etcd:4001"},
-	})
+	etcd := NewEtcdConfig(json.RawMessage(`{"endpoints":["http://etcd:4001"]}`))
 	config := &Config{
 		Services: []*ServiceConfig{
 			&ServiceConfig{
@@ -28,6 +28,24 @@ func setupEtcd(serviceName string) *Config {
 		},
 	}
 	return config
+}
+
+func TestEtcdParseArrayEndpoints(t *testing.T) {
+	cfg := NewEtcdConfig(json.RawMessage(`{"endpoints":["http://etcd:4001"]}`))
+	expected := []string{"http://etcd:4001"}
+	actual := cfg.Client.Endpoints()
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected endpoints %v but got %v", expected, actual)
+	}
+}
+
+func TestEtcdParseStringEndpoints(t *testing.T) {
+	cfg := NewEtcdConfig(json.RawMessage(`{"endpoints":"http://etcd:4001"}`))
+	expected := []string{"http://etcd:4001"}
+	actual := cfg.Client.Endpoints()
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected endpoints %v but got %v", expected, actual)
+	}
 }
 
 func TestEtcdTTLPass(t *testing.T) {


### PR DESCRIPTION
Fixes #92 

- Extract json marshaling into etcd
- Ensure correct handling of []interface{} endpoints
- Create unit tests for parsing both string and array endpoints