### PR TITLE
support setting the ip that will be advertised explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Service fields:
 - `port` is the port the service will advertise to Consul.
 - `health` is the executable (and its arguments) used to check the health of the service.
 - `interfaces` is an optional single or array of interface specifications. If given, the IP of the service will be obtained from the first interface specification that matches. (Default value is `["eth0:inet"]`)
+- `ipaddress` is an optional field to specify an IP that will override what is obtained from traversing network interfaces. This can be useful in special cases such as during testing or when using bridged networking.
 - `poll` is the time in seconds between polling for health checks.
 - `ttl` is the time-to-live of a successful health check. This should be longer than the polling rate so that the polling process and the TTL aren't racing; otherwise Consul will mark the service as unhealthy.
 - `tags` is an optional array of tags. If the discovery service supports it (Consul does), the service will register itself with these tags.

--- a/containerbuddy/config.go
+++ b/containerbuddy/config.go
@@ -65,9 +65,8 @@ type ServiceConfig struct {
 	TTL              int             `json:"ttl"`
 	Interfaces       json.RawMessage `json:"interfaces"`
 	Tags             []string        `json:"tags,omitempty"`
-	Ip               string          `json:"ip,omitempty"`
+	IpAddress        string          `json:"ipaddress,omitempty"`
 	discoveryService DiscoveryService
-	ipAddress        string
 	healthCheckCmd   *exec.Cmd
 }
 
@@ -312,8 +311,8 @@ func initializeConfig(config *Config) (*Config, error) {
 			return nil, ifaceErr
 		}
 
-		if service.Ip == "" {
-			if service.ipAddress, err = GetIP(interfaces); err != nil {
+		if service.IpAddress == "" {
+			if service.IpAddress, err = GetIP(interfaces); err != nil {
 				return nil, err
 			}
 		}

--- a/containerbuddy/config.go
+++ b/containerbuddy/config.go
@@ -65,6 +65,7 @@ type ServiceConfig struct {
 	TTL              int             `json:"ttl"`
 	Interfaces       json.RawMessage `json:"interfaces"`
 	Tags             []string        `json:"tags,omitempty"`
+	Ip               string          `json:"ip,omitempty"`
 	discoveryService DiscoveryService
 	ipAddress        string
 	healthCheckCmd   *exec.Cmd
@@ -311,8 +312,10 @@ func initializeConfig(config *Config) (*Config, error) {
 			return nil, ifaceErr
 		}
 
-		if service.ipAddress, err = GetIP(interfaces); err != nil {
-			return nil, err
+		if service.Ip == "" {
+			if service.ipAddress, err = GetIP(interfaces); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/containerbuddy/config.go
+++ b/containerbuddy/config.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"strings"
@@ -314,6 +315,11 @@ func initializeConfig(config *Config) (*Config, error) {
 		if service.IpAddress == "" {
 			if service.IpAddress, err = GetIP(interfaces); err != nil {
 				return nil, err
+			}
+		} else {
+			if err := net.ParseIP(service.IpAddress); err == nil {
+				return nil, fmt.Errorf("Could not parse `ipaddress` in service %s",
+					service.Name)
 			}
 		}
 	}

--- a/containerbuddy/config.go
+++ b/containerbuddy/config.go
@@ -317,7 +317,7 @@ func initializeConfig(config *Config) (*Config, error) {
 				return nil, err
 			}
 		} else {
-			if err := net.ParseIP(service.IpAddress); err == nil {
+			if ok := net.ParseIP(service.IpAddress); ok == nil {
 				return nil, fmt.Errorf("Could not parse `ipaddress` in service %s",
 					service.Name)
 			}

--- a/containerbuddy/config_test.go
+++ b/containerbuddy/config_test.go
@@ -242,6 +242,15 @@ func TestInvalidConfigParseNoDiscovery(t *testing.T) {
 	testParseExpectError(t, "{}", "No discovery backend defined")
 }
 
+func TestInvalidConfigIP(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	var testConfig *Config
+	testConfig = unmarshaltestJSON()
+	testConfig.Services[0].IpAddress = "fake"
+	tj, _ := json.Marshal(testConfig)
+	testParseExpectError(t, string(tj), "Could not parse `ipaddress` in service serviceA")
+}
+
 func TestInvalidConfigParseFile(t *testing.T) {
 	defer argTestCleanup(argTestSetup())
 	testParseExpectError(t, "file:///xxxx",

--- a/containerbuddy/consul.go
+++ b/containerbuddy/consul.go
@@ -62,7 +62,7 @@ func (c *Consul) registerService(service ServiceConfig) error {
 			Name:    service.Name,
 			Tags:    service.Tags,
 			Port:    service.Port,
-			Address: service.ipAddress,
+			Address: service.IpAddress,
 		},
 	)
 }

--- a/containerbuddy/consul_test.go
+++ b/containerbuddy/consul_test.go
@@ -12,7 +12,7 @@ func setupConsul(serviceName string) *Config {
 			&ServiceConfig{
 				ID:               serviceName,
 				Name:             serviceName,
-				ipAddress:        "192.168.1.1",
+				IpAddress:        "192.168.1.1",
 				TTL:              1,
 				Port:             9000,
 				discoveryService: consul,

--- a/containerbuddy/etcd.go
+++ b/containerbuddy/etcd.go
@@ -229,7 +229,7 @@ func encodeEtcdNodeValue(service *ServiceConfig) string {
 	node := &EtcdServiceNode{
 		ID:      service.ID,
 		Name:    service.Name,
-		Address: service.ipAddress,
+		Address: service.IpAddress,
 		Port:    service.Port,
 	}
 	json, err := json.Marshal(&node)

--- a/containerbuddy/etcd_test.go
+++ b/containerbuddy/etcd_test.go
@@ -14,7 +14,7 @@ func setupEtcd(serviceName string) *Config {
 			&ServiceConfig{
 				ID:               serviceName,
 				Name:             serviceName,
-				ipAddress:        "192.168.1.1",
+				IpAddress:        "192.168.1.1",
 				TTL:              1,
 				Port:             9000,
 				discoveryService: etcd,


### PR DESCRIPTION
..in order to support bridged mode docker users.

https://github.com/joyent/containerbuddy/issues/102