### PR TITLE
SHELLFLAGS needs to end with (-)c in order to tell bash what to run

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 MAKEFLAGS += --warn-undefined-variables
 SHELL := /bin/bash
-.SHELLFLAGS := -eu -o pipefail
+.SHELLFLAGS := -o pipefail -euc
 .DEFAULT_GOAL := build
 
 .PHONY: clean test integration consul etcd run-consul run-etcd example example-consul example-etcd ship dockerfile docker cover lint


### PR DESCRIPTION
Not sure why this wasn't encountered, but on Ubuntu 16.04 I have an issue where 'make vendor' results in:

`/bin/bash: git rev-parse --short HEAD: No such file or directory
/bin/pwd: /bin/pwd: cannot execute binary file
mkdir -p /build
/bin/bash: mkdir -p /build: No such file or directory
makefile:57: recipe for target 'build/containerbuddy_build' failed
make: *** [build/containerbuddy_build] Error 127`

Strace reveals bash being run incorrectly (missing -c):

`[pid  2240] execve("/bin/bash", ["/bin/bash", "-eu", "-o", "pipefail", "git rev-parse --short HEAD"], [/* 77 vars */]) = 0`

Interestingly the Makefile.docker file does have the correct options:
Makefile.docker:.SHELLFLAGS = -o pipefail -euc