### PR TITLE
logging: Do not attempt to handle Fatal and Panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The format of the JSON file configuration is as follows:
   "onStart": "/opt/containerbuddy/onStart-script.sh {{.ENV_VAR_NAME}}",
   "logging": {
     "level": "INFO",
-    "format": "go",
+    "format": "default",
     "output": "stdout"
   },
   "stopTimeout": 5,

--- a/containerbuddy/logging.go
+++ b/containerbuddy/logging.go
@@ -79,13 +79,7 @@ type DefaultLogFormatter struct {
 func (f *DefaultLogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	b := &bytes.Buffer{}
 	logger := log.New(b, "", log.LstdFlags)
-	switch entry.Level {
-	case logrus.PanicLevel:
-		logger.Panicln(entry.Message)
-	case logrus.FatalLevel:
-		logger.Fatalln(entry.Message)
-	default:
-		logger.Println(entry.Message)
-	}
+	logger.Println(entry.Message)
+	// Panic and Fatal are handled by logrus automatically
 	return b.Bytes(), nil
 }

--- a/containerbuddy/logging_test.go
+++ b/containerbuddy/logging_test.go
@@ -42,3 +42,26 @@ func TestLoggingConfigInit(t *testing.T) {
 	// Reset to defaults
 	defaultLog.init()
 }
+
+func TestDefaultFormatterEmptyMessage(t *testing.T) {
+	formatter := &DefaultLogFormatter{}
+	_, err := formatter.Format(logrus.WithFields(
+		logrus.Fields{
+			"level": "info",
+			"msg":   "something",
+		},
+	))
+	if err != nil {
+		t.Errorf("Did not expect error: %v", err)
+	}
+}
+
+func TestDefaultFormatterPanic(t *testing.T) {
+	defaultLog.init()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic but did not")
+		}
+	}()
+	logrus.Panicln("Panic Test")
+}


### PR DESCRIPTION
Logrus automatically handles os.Exit and panic when using the appropriate log levels, so it is unnecessary to do so in the formatter

Fixes #105