### PR TITLE
Parse scheme from Consul configuration string

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Service Discovery Backends:
 
 Must supply only one of the following
 
-- `consul` configures discovery via [Hashicorp Consul](https://www.consul.io/). Expects `hostname:port` string:
+- `consul` configures discovery via [Hashicorp Consul](https://www.consul.io/). Expects `hostname:port` string. If you are communicating with Consul over TLS you may include the scheme (ex. `https://consul:8500`):
 
     ```
     "consul": "consul:8500"

--- a/containerbuddy/consul.go
+++ b/containerbuddy/consul.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	consul "github.com/hashicorp/consul/api"
@@ -14,9 +15,11 @@ type Consul struct{ consul.Client }
 
 // NewConsulConfig creates a new service discovery backend for Consul
 func NewConsulConfig(uri string) Consul {
+
+	address, scheme := parseRawUri(uri)
 	defaultconfig := consul.Config{
-		Address: uri,
-		Scheme:  "http",
+		Address: address,
+		Scheme:  scheme,
 	}
 
 	if token := os.Getenv("CONSUL_HTTP_TOKEN"); token != "" {
@@ -26,6 +29,22 @@ func NewConsulConfig(uri string) Consul {
 	client, _ := consul.NewClient(&defaultconfig)
 	config := &Consul{*client}
 	return *config
+}
+
+// Returns the uri broken into an address and scheme portion
+func parseRawUri(raw string) (string, string) {
+
+	var scheme = "http" // default
+	var address = raw   // we accept bare address w/o a scheme
+
+	// strip the scheme from the prefix and (maybe) set the scheme to https
+	if strings.HasPrefix(raw, "http://") {
+		address = strings.Replace(raw, "http://", "", 1)
+	} else if strings.HasPrefix(raw, "https://") {
+		address = strings.Replace(raw, "https://", "", 1)
+		scheme = "https"
+	}
+	return address, scheme
 }
 
 // Deregister removes the node from Consul.

--- a/containerbuddy/consul_test.go
+++ b/containerbuddy/consul_test.go
@@ -28,6 +28,30 @@ func setupConsul(serviceName string) *Config {
 	return config
 }
 
+func TestConsulAddressParse(t *testing.T) {
+	// typical valid entries
+	runParseTest(t, "https://consul:8500", "consul:8500", "https")
+	runParseTest(t, "http://consul:8500", "consul:8500", "http")
+	runParseTest(t, "consul:8500", "consul:8500", "http")
+
+	// malformed URI: we won't even try to fix these and just let them bubble up
+	// to the Consul API call where it'll fail there.
+	runParseTest(t, "httpshttps://consul:8500", "httpshttps://consul:8500", "http")
+	runParseTest(t, "https://https://consul:8500", "https://consul:8500", "https")
+	runParseTest(t, "http://https://consul:8500", "https://consul:8500", "http")
+	runParseTest(t, "consul:8500https://", "consul:8500https://", "http")
+	runParseTest(t, "", "", "http")
+}
+
+func runParseTest(t *testing.T, uri, expectedAddress, expectedScheme string) {
+
+	address, scheme := parseRawUri(uri)
+	if address != expectedAddress || scheme != expectedScheme {
+		t.Fatalf("Expected %s over %s but got %s over %s",
+			expectedAddress, expectedScheme, address, scheme)
+	}
+}
+
 func TestConsulTTLPass(t *testing.T) {
 	config := setupConsul("service-TestConsulTTLPass")
 	service := config.Services[0]

--- a/integration_tests/fixtures/test_probe/Dockerfile
+++ b/integration_tests/fixtures/test_probe/Dockerfile
@@ -1,8 +1,8 @@
 FROM golang:latest
+ENV GO15VENDOREXPERIMENT 1
 
-RUN go get github.com/hashicorp/consul
-RUN go get github.com/samalba/dockerclient
-RUN go get github.com/coreos/etcd/client
+RUN go get github.com/tools/godep
 
 COPY src /go/src/test_probe
+RUN cd /go/src/test_probe && godep restore
 RUN go install test_probe

--- a/integration_tests/fixtures/test_probe/src/Godeps/Godeps.json
+++ b/integration_tests/fixtures/test_probe/src/Godeps/Godeps.json
@@ -1,0 +1,46 @@
+{
+	"ImportPath": "test_probe",
+	"GoVersion": "go1.5",
+	"GodepVersion": "v60",
+	"Deps": [
+		{
+			"ImportPath": "github.com/coreos/etcd/Godeps/_workspace/src/github.com/ugorji/go/codec",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/client",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/pathutil",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/types",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/docker/go-units",
+			"Comment": "v0.3.0",
+			"Rev": "5d2041e26a699eaca682e2ea41c8f891e1060444"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/consul/api",
+			"Comment": "v0.5.2-461-g158eabd",
+			"Rev": "158eabdd6f2408067c1d7656fa10e49434f96480"
+		},
+		{
+			"ImportPath": "github.com/samalba/dockerclient",
+			"Rev": "f274bbd0e2eb35ad1444dc6e6660214f9fbbc08c"
+		}
+	]
+}


### PR DESCRIPTION
For https://github.com/joyent/containerbuddy/issues/112.

Users who are securing communication with Consul via TLS should be able to include the scheme in the URI provided and have that picked up by the config constructor. By parsing it out of the string rather than forcing the user to use a structure config like the Etcd backend, we can add support for TLS without breaking backwards compatibility. This means that all the following are valid Consul config entries:

```json
{
  "consul": "consul:8500",
  "consul": "https://consul:8500",
  "consul": "http://consul:8500",
}
```

cc @misterbisson @justenwalker 