### PR TITLE
Pin dependencies for test_probe fixture

### DIFF
--- a/integration_tests/fixtures/test_probe/Dockerfile
+++ b/integration_tests/fixtures/test_probe/Dockerfile
@@ -1,8 +1,8 @@
 FROM golang:latest
+ENV GO15VENDOREXPERIMENT 1
 
-RUN go get github.com/hashicorp/consul
-RUN go get github.com/samalba/dockerclient
-RUN go get github.com/coreos/etcd/client
+RUN go get github.com/tools/godep
 
 COPY src /go/src/test_probe
+RUN cd /go/src/test_probe && godep restore
 RUN go install test_probe

--- a/integration_tests/fixtures/test_probe/src/Godeps/Godeps.json
+++ b/integration_tests/fixtures/test_probe/src/Godeps/Godeps.json
@@ -1,0 +1,46 @@
+{
+	"ImportPath": "test_probe",
+	"GoVersion": "go1.5",
+	"GodepVersion": "v60",
+	"Deps": [
+		{
+			"ImportPath": "github.com/coreos/etcd/Godeps/_workspace/src/github.com/ugorji/go/codec",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/client",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/pathutil",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/types",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/docker/go-units",
+			"Comment": "v0.3.0",
+			"Rev": "5d2041e26a699eaca682e2ea41c8f891e1060444"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/consul/api",
+			"Comment": "v0.5.2-461-g158eabd",
+			"Rev": "158eabdd6f2408067c1d7656fa10e49434f96480"
+		},
+		{
+			"ImportPath": "github.com/samalba/dockerclient",
+			"Rev": "f274bbd0e2eb35ad1444dc6e6660214f9fbbc08c"
+		}
+	]
+}


### PR DESCRIPTION
@misterbisson @justenwalker this pins the dependencies for the test_probe.go integration test fixture. This should prevent the Consul API dependency (which is currently broken at the HEAD of master) from breaking our integration tests. ref https://github.com/joyent/containerbuddy/pull/113#issuecomment-201021419