### PR TITLE
Deprecate onStart in lieu of preStart

### DIFF
--- a/containerbuddy/config_test.go
+++ b/containerbuddy/config_test.go
@@ -14,7 +14,7 @@ import (
 
 var testJSON = `{
 	"consul": "consul:8500",
-	"onStart": "/bin/to/onStart.sh arg1 arg2",
+	"preStart": "/bin/to/preStart.sh arg1 arg2",
 	"preStop": ["/bin/to/preStop.sh","arg1","arg2"],
 	"postStop": ["/bin/to/postStop.sh"],
 	"services": [
@@ -87,7 +87,7 @@ func TestValidConfigParse(t *testing.T) {
 		t.Errorf("Expected no tag for upstreamB, but got: %s", config.Backends[1].Tag)
 	}
 
-	validateCommandParsed(t, "onStart", config.onStartCmd, []string{"/bin/to/onStart.sh", "arg1", "arg2"})
+	validateCommandParsed(t, "preStart", config.preStartCmd, []string{"/bin/to/preStart.sh", "arg1", "arg2"})
 	validateCommandParsed(t, "preStop", config.preStopCmd, []string{"/bin/to/preStop.sh", "arg1", "arg2"})
 	validateCommandParsed(t, "postStop", config.postStopCmd, []string{"/bin/to/postStop.sh"})
 	validateCommandParsed(t, "health", config.Services[0].healthCheckCmd, []string{"/bin/to/healthcheck/for/service/A.sh"})

--- a/containerbuddy/main.go
+++ b/containerbuddy/main.go
@@ -22,9 +22,9 @@ func Main() {
 		log.Fatal(configErr)
 	}
 
-	// Run the onStart handler, if any, and exit if it returns an error
-	if onStartCode, err := run(config.onStartCmd); err != nil {
-		os.Exit(onStartCode)
+	// Run the preStart handler, if any, and exit if it returns an error
+	if preStartCode, err := run(config.preStartCmd); err != nil {
+		os.Exit(preStartCode)
 	}
 
 	// Set up handlers for polling and to accept signal interrupts

--- a/integration_tests/fixtures/app/app-with-consul.json
+++ b/integration_tests/fixtures/app/app-with-consul.json
@@ -1,6 +1,6 @@
 {
   "consul": "consul:8500",
-  "onStart": "/reload-app.sh",
+  "preStart": "/reload-app.sh",
   "services": [
     {
       "name": "app",

--- a/integration_tests/fixtures/app/app-with-etcd.json
+++ b/integration_tests/fixtures/app/app-with-etcd.json
@@ -3,7 +3,7 @@
       "endpoints": "http://etcd:4001",
       "prefix": "/containerbuddy"
   },
-  "onStart": "/reload-app-etcd.sh",
+  "preStart": "/reload-app-etcd.sh",
   "services": [
     {
       "name": "app",

--- a/integration_tests/fixtures/nginx/etc/nginx-with-consul.json
+++ b/integration_tests/fixtures/nginx/etc/nginx-with-consul.json
@@ -1,6 +1,6 @@
 {
   "consul": "consul:8500",
-  "onStart": [
+  "preStart": [
     "consul-template", "-once", "-retry", "30s", "-consul", "consul:8500", "-template",
     "/etc/nginx-consul.ctmpl:/etc/nginx/nginx.conf"
   ],

--- a/integration_tests/fixtures/test_probe/Dockerfile
+++ b/integration_tests/fixtures/test_probe/Dockerfile
@@ -1,8 +1,8 @@
 FROM golang:latest
+ENV GO15VENDOREXPERIMENT 1
 
-RUN go get github.com/hashicorp/consul
-RUN go get github.com/samalba/dockerclient
-RUN go get github.com/coreos/etcd/client
+RUN go get github.com/tools/godep
 
 COPY src /go/src/test_probe
+RUN cd /go/src/test_probe && godep restore
 RUN go install test_probe

--- a/integration_tests/fixtures/test_probe/src/Godeps/Godeps.json
+++ b/integration_tests/fixtures/test_probe/src/Godeps/Godeps.json
@@ -1,0 +1,46 @@
+{
+	"ImportPath": "test_probe",
+	"GoVersion": "go1.5",
+	"GodepVersion": "v60",
+	"Deps": [
+		{
+			"ImportPath": "github.com/coreos/etcd/Godeps/_workspace/src/github.com/ugorji/go/codec",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/client",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/pathutil",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/coreos/etcd/pkg/types",
+			"Comment": "v2.2.5-1-g6bc9b6e",
+			"Rev": "6bc9b6e4edf44b59bb99b3761e4461a1ba608b0b"
+		},
+		{
+			"ImportPath": "github.com/docker/go-units",
+			"Comment": "v0.3.0",
+			"Rev": "5d2041e26a699eaca682e2ea41c8f891e1060444"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/consul/api",
+			"Comment": "v0.5.2-461-g158eabd",
+			"Rev": "158eabdd6f2408067c1d7656fa10e49434f96480"
+		},
+		{
+			"ImportPath": "github.com/samalba/dockerclient",
+			"Rev": "f274bbd0e2eb35ad1444dc6e6660214f9fbbc08c"
+		}
+	]
+}


### PR DESCRIPTION
For https://github.com/joyent/containerbuddy/issues/109

To improve the clarity of configuration, we're changing the `onStart` option to `preStart`.

For purposes of backwards compatibility the deprecation behavior is as follows. If `onStart` is provided without `preStart`, warn the user and alias the `onStart` to a `preStart`. If both `onStart` and `preStart` are provided, warn the user and use only the `preStart`.

#109 proposed logging at WARN but this section of the code is prior to the logging configuration being setup so it will simply send to stdout like our other pre-logging-config messages.

cc @misterbisson @justenwalker 