### PR TITLE
Avoid racing reparent in zombie-reaping integration test

### DIFF
--- a/integration_tests/tests/test_reap_zombies/run.sh
+++ b/integration_tests/tests/test_reap_zombies/run.sh
@@ -1,16 +1,30 @@
 #!/bin/bash
+# Test to verify that we're correctly reaping zombies.
+# At any given time we may have up to 1 zombie parented to PID1 (it has been
+# reparented but not yet reaped) and 1 zombie not yet parented to PID1.
+# We can't test any more precisely than this without racing the kernel
+# reparenting mechanism.
 
 docker-compose up -d consul app > /dev/null 2>&1
 APP_ID="$(docker-compose ps -q app)"
 sleep 6
-NUM_ZOMBIES=$(docker exec $APP_ID ps -o stat,ppid,pid,comm | awk '
+
+PTREE=$(docker exec $APP_ID ps -o stat,ppid,pid,comm)
+REPARENTED_ZOMBIES=$(echo $PTREE | awk '
 BEGIN { count=0 }
-$1 ~ /^Z/ && $2 ~ /1/ { count++ }
+$1 ~ /^Z/ && $2 ~ /^1$/ { count++ }
 END { print count }
 ')
-if [ $NUM_ZOMBIES -gt 1 ]; then
-  echo "Number of zombies > 1: $NUM_ZOMBIES" >&2
-  docker exec $APP_ID ps -o stat,ppid,pid,args
+
+TOTAL_ZOMBIES=$(echo $PTREE | awk '
+BEGIN { count=0 }
+$1 ~ /^Z/ { count++ }
+END { print count }
+')
+
+if [ $REPARENTED_ZOMBIES -gt 1 ] || [ $TOTAL_ZOMBIES -gt 2 ]; then
+  echo "More than permitted number of zombies." >&2
+  echo $PTREE >&2
   docker logs $APP_ID
   exit 1
 fi


### PR DESCRIPTION
At any given time we may have up to 1 zombie parented to PID1 (it has been reparented but not yet reaped) and 1 zombie not yet parented to PID1. We can't test any more precisely than this without racing the kernel reparenting mechanism (`do_exit()`).

Also updated the test to capture the ps tree only once so that we don't log something different from what we tested.

cc @justenwalker per our discussion in https://github.com/joyent/containerbuddy/pull/119